### PR TITLE
Refactor code

### DIFF
--- a/buildzr/__init__.py
+++ b/buildzr/__init__.py
@@ -1,2 +1,3 @@
 from . import models
 from . import encoders
+from .dsl import interfaces


### PR DESCRIPTION
This commit refactor the `dsl.py` module so that the abstract classes are in a separate module (now in `buildzr.dsl.interfaces`) module.

New abstract classes are introduced to tackle the issue where the abstract class refers concrete classes directly (e.g., `_UsesFrom` concrete class referenced by the `DslElement` abstract class; now `DslElement` refer to `BindLeft`, an abstract represetation of `_UsesFrom`).