### PR TITLE
Set implied relationship in the `where` function

### DIFF
--- a/tests/samples/implied_relationships.py
+++ b/tests/samples/implied_relationships.py
@@ -9,11 +9,6 @@ class SampleImpliedRelationships(AbstractBuilder):
 
     def build(self) -> buildzr.models.Workspace:
 
-        # There should be an implied relationship where
-        # u >> "Runs SQL queries" >> s after when we enable implied
-        # relationships.
-        EnableImpliedRelationships()
-
         w = Workspace("w")\
                 .contains(
                     Person("u"),
@@ -33,10 +28,10 @@ class SampleImpliedRelationships(AbstractBuilder):
                         )\
                         .where(lambda webapp, database: [
                             webapp >> "Uses" >> database
-                        ])
+                        ], implied=True)
                 )\
                 .where(lambda u, s: [
-                    u >> "Runs SQL queries" >> s.database
-                ])
+                    u >> "Runs SQL queries" >> s.database,
+                ], implied=True)
 
         return w.model

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -381,11 +381,11 @@ def test_implied_relationship() -> Optional[None]:
                     )\
                     .where(lambda webapp, database: [
                         webapp >> "Uses" >> database
-                    ])
+                    ], implied=True)
             )\
             .where(lambda u, s: [
                 u >> "Runs SQL queries" >> s.database
-            ])
+            ], implied=True)
 
     assert isinstance(w.u, Person)
     assert isinstance(w.s, SoftwareSystem)


### PR DESCRIPTION
Instead of relying on a singleton to enable/disable implied relationships, we set this in the `where` function instead, where relationships (in fluent api) are defined.

Unfortunately, this doesn't cover relationships that are not defined using the `where` function.