### PR TITLE
feat(dsl): add type checks for relationships

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.pull_request.base.sha }}
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Set up Python
       uses: actions/setup-python@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Get HEAD commit message
         id: get-head-commit-message
-        run: echo "::set-output name=commit_message::$(git log --format=%B -n 1)"
+        run: echo "commit_message='$(git log --format=%B -n 1)'"
 
   commitlint:
     runs-on: ubuntu-latest
@@ -58,7 +58,11 @@ jobs:
       - commitlint
       - check_changes
 
-    if: ${{ !contains(needs.check_skip_flags.outputs.head-commit-message, '[skip-ci]') && needs.check_changes.outputs.src == 'true' }}
+    if: |
+      ${{
+        !contains(needs.check_skip_flags.outputs.head-commit-message, '[skip-ci]') &&
+        needs.check_changes.outputs.src == 'true'
+      }}
 
     steps:
     - name: Checkout code

--- a/buildzr/__about__.py
+++ b/buildzr/__about__.py
@@ -1,1 +1,1 @@
-VERSION = "0.0.6"
+VERSION = "0.0.7.dev0"

--- a/buildzr/__about__.py
+++ b/buildzr/__about__.py
@@ -1,1 +1,1 @@
-VERSION = "0.0.7.dev3"
+VERSION = "0.0.7.dev5"

--- a/buildzr/__about__.py
+++ b/buildzr/__about__.py
@@ -1,1 +1,1 @@
-VERSION = "0.0.7.dev0"
+VERSION = "0.0.7.dev3"

--- a/buildzr/dsl/dsl.py
+++ b/buildzr/dsl/dsl.py
@@ -199,7 +199,15 @@ class Workspace(DslWorkspaceElement):
     def __dir__(self) -> Iterable[str]:
         return list(super().__dir__()) + list(self._dynamic_attrs.keys())
 
-class SoftwareSystem(DslElementRelationOverrides):
+class SoftwareSystem(DslElementRelationOverrides[
+    'SoftwareSystem',
+    Union[
+        'Person',
+        'SoftwareSystem',
+        'Container',
+        'Component'
+    ]
+]):
     """
     A software system.
     """
@@ -284,7 +292,15 @@ class SoftwareSystem(DslElementRelationOverrides):
     def __dir__(self) -> Iterable[str]:
         return list(super().__dir__()) + list(self._dynamic_attrs.keys())
 
-class Person(DslElementRelationOverrides):
+class Person(DslElementRelationOverrides[
+    'Person',
+    Union[
+        'Person',
+        'SoftwareSystem',
+        'Container',
+        'Component'
+    ]
+]):
     """
     A person who uses a software system.
     """
@@ -335,7 +351,15 @@ class Person(DslElementRelationOverrides):
         self._label = label
         return self
 
-class Container(DslElementRelationOverrides):
+class Container(DslElementRelationOverrides[
+    'Container',
+    Union[
+        'Person',
+        'SoftwareSystem',
+        'Container',
+        'Component'
+    ]
+]):
     """
     A container (something that can execute code or host data).
     """
@@ -415,7 +439,15 @@ class Container(DslElementRelationOverrides):
     def __dir__(self) -> Iterable[str]:
         return list(super().__dir__()) + list(self._dynamic_attrs.keys())
 
-class Component(DslElementRelationOverrides):
+class Component(DslElementRelationOverrides[
+    'Component',
+    Union[
+        'Person',
+        'SoftwareSystem',
+        'Container',
+        'Component'
+    ]
+]):
     """
     A component (a grouping of related functionality behind an interface that runs inside a container).
     """

--- a/buildzr/dsl/dsl.py
+++ b/buildzr/dsl/dsl.py
@@ -519,6 +519,9 @@ class _FluentSink(DslFluentSink):
         sink = JsonSink()
         sink.write(workspace=self._workspace.model, config=JsonSinkConfig(path=path))
 
+    def get_workspace(self) -> Workspace:
+        return self._workspace
+
 _RankDirection = Literal['tb', 'bt', 'lr', 'rl']
 
 _AutoLayout = Optional[

--- a/buildzr/dsl/relations.py
+++ b/buildzr/dsl/relations.py
@@ -204,6 +204,8 @@ class _FluentRelationship(DslFluentRelationship[TParent]):
 
         return self._parent
 
+    # TODO: Remove this and replace with something better.
+    # Doesn't feel "fluent."
     def get(self) -> TParent:
         return self._parent
 
@@ -306,7 +308,7 @@ class _UsesFromLate(BindLeftLate[TDst]):
 
         return self
 
-class DslElementRelationOverrides(DslElement):
+class DslElementRelationOverrides(Generic[TSrc, TDst], DslElement[TSrc, TDst]):
 
     """
     Base class meant to be derived from to override the `__rshift__` method to
@@ -316,7 +318,7 @@ class DslElementRelationOverrides(DslElement):
 
     # TODO: Check why need to ignore the override error here.
     @overload  # type: ignore[override]
-    def __rshift__(self, other: DslElement) -> _Relationship[Self, DslElement]:
+    def __rshift__(self, other: TDst) -> _Relationship[Self, TDst]:
         """
         Create a relationship between the source element and the destination
         without specifying description or technology.
@@ -326,30 +328,30 @@ class DslElementRelationOverrides(DslElement):
         ...
 
     @overload
-    def __rshift__(self, description_and_technology: Tuple[str, str]) -> _UsesFrom[Self, DslElement]:
+    def __rshift__(self, description_and_technology: Tuple[str, str]) -> _UsesFrom[Self, TDst]:
         ...
 
     @overload
-    def __rshift__(self, description: str) -> _UsesFrom[Self, DslElement]:
+    def __rshift__(self, description: str) -> _UsesFrom[Self, TDst]:
         ...
 
     @overload
-    def __rshift__(self, _RelationshipDescription: _RelationshipDescription[DslElement]) -> _UsesFrom[Self, DslElement]:
+    def __rshift__(self, _RelationshipDescription: _RelationshipDescription[TDst]) -> _UsesFrom[Self, TDst]:
         ...
 
     @overload
-    def __rshift__(self, multiple_destinations: List[Union[DslElement, _UsesFromLate[DslElement]]]) -> List[_Relationship[Self, DslElement]]:
+    def __rshift__(self, multiple_destinations: List[Union[TDst, _UsesFromLate[TDst]]]) -> List[_Relationship[Self, TDst]]:
         ...
 
     def __rshift__(
             self,
             other: Union[
-                DslElement,
+                TDst,
                 str,
                 Tuple[str, str],
-                _RelationshipDescription[DslElement],
-                List[Union[DslElement, _UsesFromLate[DslElement]]]
-            ]) -> Union[_UsesFrom[Self, DslElement], _Relationship[Self, DslElement], List[_Relationship[Self, DslElement]]]:
+                _RelationshipDescription[TDst],
+                List[Union[TDst, _UsesFromLate[TDst]]]
+            ]) -> Union[_UsesFrom[Self, TDst], _Relationship[Self, TDst], List[_Relationship[Self, TDst]]]:
         if isinstance(other, DslElement):
             return cast(
                 _Relationship[Self, DslElement],

--- a/tests/test_typehints.py
+++ b/tests/test_typehints.py
@@ -1,0 +1,247 @@
+# All tests in this file are to ensure that the typehints are correct.
+# IMPORTANT: Run pytest with --mypy flag to check for typehint errors.
+
+from typing import Optional
+from buildzr.dsl import (
+    Workspace,
+    Person,
+    SoftwareSystem,
+    Container,
+    Component,
+    desc,
+)
+
+def test_relationship_typehint_person_to_person() -> Optional[None]:
+
+    w = (
+        Workspace("w")
+        .contains(
+            Person("p1"),
+            Person("p2"),
+            Person("p3"),
+            Person("p4"),
+        )
+        .where(lambda w: [
+            w.person().p1 >> "greet" >> w.person().p2,
+            w.person().p1 >> [
+                w.person().p3,
+                desc("greet") >> w.person().p4,
+            ]
+        ])
+    )
+
+def test_relationship_typehint_person_to_software_system() -> Optional[None]:
+
+    w = (
+        Workspace("w")
+        .contains(
+            Person("p"),
+            SoftwareSystem("s1"),
+            SoftwareSystem("s2"),
+            SoftwareSystem("s3"),
+            SoftwareSystem("s4"),
+        )
+        .where(lambda w: [
+            w.person().p >> "use" >> w.software_system().s1,
+            w.person().p >> [
+                w.software_system().s2,
+                desc("use") >> w.software_system().s3,
+                desc("use") >> w.software_system().s4,
+            ]
+        ])
+    )
+
+def test_relationship_typehint_person_to_container() -> Optional[None]:
+
+    w = (
+        Workspace("w")
+        .contains(
+            Person('p'),
+            SoftwareSystem('s')
+            .contains(
+                Container('c1'),
+                Container('c2'),
+                Container('c3'),
+                Container('c4'),
+            )
+        )
+        .where(lambda w: [
+            w.person().p >> "use" >> w.software_system().s.container().c1,
+            w.person().p >> [
+                w.software_system().s.container().c2,
+                desc("use") >> w.software_system().s.container().c3,
+                desc("use") >> w.software_system().s.container().c4,
+            ]
+        ])
+    )
+
+def test_relationship_typehint_person_to_component() -> Optional[None]:
+
+    w = (
+        Workspace("w")
+        .contains(
+            Person('p'),
+            SoftwareSystem('s')
+            .contains(
+                Container('c')
+                .contains(
+                    Component('c1'),
+                    Component('c2'),
+                    Component('c3'),
+                    Component('c4'),
+                )
+            )
+        )
+        .where(lambda w: [
+            w.person().p >> "use" >> w.software_system().s.container().c.component().c1,
+            w.person().p >> [
+                w.software_system().s.container().c.component().c2,
+                desc("use") >> w.software_system().s.container().c.component().c3,
+                desc("use") >> w.software_system().s.container().c.component().c4,
+            ]
+        ])
+    )
+
+def test_relationship_typehint_software_system_to_software_system() -> Optional[None]:
+
+    w = (
+        Workspace("w")
+        .contains(
+            SoftwareSystem("s1"),
+            SoftwareSystem("s2"),
+            SoftwareSystem("s3"),
+            SoftwareSystem("s4"),
+        )
+        .where(lambda w: [
+            w.software_system().s1 >> "integrate" >> w.software_system().s2,
+            w.software_system().s1 >> [
+                w.software_system().s3,
+                desc("integrate") >> w.software_system().s4,
+            ]
+        ])
+    )
+
+def test_relationship_typehint_software_system_to_container() -> Optional[None]:
+
+    w = (
+        Workspace("w")
+        .contains(
+            SoftwareSystem('s1'),
+            SoftwareSystem('s2')
+            .contains(
+                Container('c1'),
+                Container('c2'),
+                Container('c3'),
+                Container('c4'),
+            )
+        )
+        .where(lambda w: [
+            w.software_system().s1 >> "use" >> w.software_system().s2.container().c1,
+            w.software_system().s1 >> [
+                w.software_system().s2.container().c2,
+                desc("use") >> w.software_system().s2.container().c3,
+                desc("use") >> w.software_system().s2.container().c4,
+            ]
+        ])
+    )
+
+def test_relationship_typehint_software_system_to_component() -> Optional[None]:
+
+    w = (
+        Workspace("w")
+        .contains(
+            SoftwareSystem('s1'),
+            SoftwareSystem('s2')
+            .contains(
+                Container('c')
+                .contains(
+                    Component('c1'),
+                    Component('c2'),
+                    Component('c3'),
+                    Component('c4'),
+                )
+            )
+        )
+        .where(lambda w: [
+            w.software_system().s1 >> "use" >> w.software_system().s2.container().c.component().c1,
+            w.software_system().s1 >> [
+                w.software_system().s2.container().c.component().c2,
+                desc("use") >> w.software_system().s2.container().c.component().c3,
+                desc("use") >> w.software_system().s2.container().c.component().c4,
+            ]
+        ])
+    )
+
+def test_relationship_typehint_container_to_container() -> Optional[None]:
+
+    w = (
+        Workspace("w")
+        .contains(
+            SoftwareSystem('s')
+            .contains(
+                Container('c1'),
+                Container('c2'),
+                Container('c3'),
+                Container('c4'),
+            )
+        )
+        .where(lambda w: [
+            w.software_system().s.container().c1 >> "call" >> w.software_system().s.container().c2,
+            w.software_system().s.container().c1 >> [
+                w.software_system().s.container().c3,
+                desc("call") >> w.software_system().s.container().c4,
+            ]
+        ])
+    )
+
+def test_relationship_typehint_container_to_component() -> Optional[None]:
+
+    w = (
+        Workspace("w")
+        .contains(
+            SoftwareSystem('s')
+            .contains(
+                Container('c1'),
+                Container('c2')
+                .contains(
+                    Component('c1'),
+                    Component('c2'),
+                    Component('c3'),
+                    Component('c4'),
+                )
+            )
+        )
+        .where(lambda w: [
+            w.software_system().s.container().c1 >> "call" >> w.software_system().s.container().c2.component().c1,
+            w.software_system().s.container().c1 >> [
+                w.software_system().s.container().c2.component().c2,
+                desc("call") >> w.software_system().s.container().c2.component().c3,
+                desc("call") >> w.software_system().s.container().c2.component().c4,
+            ]
+        ])
+    )
+
+def test_relationship_typehint_component_to_component() -> Optional[None]:
+
+    w = (
+        Workspace("w")
+        .contains(
+            SoftwareSystem('s')
+            .contains(
+                Container('c')
+                .contains(
+                    Component('c1'),
+                    Component('c2'),
+                    Component('c3'),
+                    Component('c4'),
+                )
+            )
+        )
+        .where(lambda w: [
+            w.software_system().s.container().c.component().c1 >> "call" >> w.software_system().s.container().c.component().c2,
+            w.software_system().s.container().c.component().c1 >> [
+                w.software_system().s.container().c.component().c3,
+                desc("call") >> w.software_system().s.container().c.component().c4,
+            ]
+        ])
+    )


### PR DESCRIPTION
This also adds another test file specificaly for type hints.

This is especially useful for type hinting the possible destination element for specific source element in a relationship. For example, the `Person` element, can only have either a `Person`, `SoftwareSystem`, `Container`, or `Component` as a destination; not `DeploymentNode` or `InfrastructureNode`.

Likewise, the `DeploymentNode` element can only have a `DeploymentNode` as its destination in a relationship.

This commit is added for #67 in anticipation that typehints may be false-positive to the relationship between `Person` and `DeploymentNode`, for example.