### PR TITLE
Allow devcontainer use on MacOS

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
 
 ARG USER_UID
-RUN usermod -u "${USER_UID}" vscode
+RUN if [[ -z "$USER_UID" ]]; then usermod -u "${USER_UID}" vscode; fi
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,8 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
 
+ARG USER_UID
+RUN usermod -u "${USER_UID}" vscode
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 # openjdk-21-jdk will be needed for Structurizr's C4 DSL language server.

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,11 +9,11 @@ RUN apt update && \
         graphviz \
         pipx
 
-COPY  deps/install_structurizr_cli.sh .
+COPY  deps/install_structurizr_cli.sh ./
 RUN chmod +x install_structurizr_cli.sh
 RUN ./install_structurizr_cli.sh
 
-COPY deps/install_structurizr_lite.sh deps/structurizr-lite.sh .
+COPY deps/install_structurizr_lite.sh deps/structurizr-lite.sh ./
 RUN chmod +x install_structurizr_lite.sh && \
     ./install_structurizr_lite.sh
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,17 @@
 {
     "build": {
-        "dockerfile": "Dockerfile"
+        "dockerfile": "Dockerfile",
+        "args": {
+            "USER_UID": "${env:USER_UID}"
+        }
     },
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace/buildzr,type=bind",
+    "workspaceFolder": "/workspace/buildzr",
+    "mounts": [
+        "source=${env:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,readonly"
+   ],
+   "remoteUser": "vscode",
+    "postStartCommand": "chmod 700 /home/vscode/.ssh && chmod 600 /home/vscode/.ssh/*",
 
     "features": {
         "ghcr.io/rocker-org/devcontainer-features/miniforge:2": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,10 +9,9 @@
     "workspaceFolder": "/workspace/buildzr",
     "mounts": [
         "source=${env:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,readonly"
-   ],
-   "remoteUser": "vscode",
+    ],
+    "remoteUser": "vscode",
     "postStartCommand": "chmod 700 /home/vscode/.ssh && chmod 600 /home/vscode/.ssh/*",
-
     "features": {
         "ghcr.io/rocker-org/devcontainer-features/miniforge:2": {},
         "ghcr.io/devcontainers/features/sshd:1": {
@@ -20,7 +19,6 @@
         },
         "ghcr.io/devcontainers/features/github-cli:1": {}
     },
-
     "customizations": {
         "vscode": {
             "extensions": [

--- a/buildzr/__about__.py
+++ b/buildzr/__about__.py
@@ -1,1 +1,1 @@
-VERSION = "0.0.9"
+VERSION = "0.0.10.dev3"


### PR DESCRIPTION
Probably will work on a Linux-based distro too, as long as vs code is started in a shell with `USER_UID` set, e.g., `export USER_UID=$(id -u)`.