### PR TITLE
fix(devcontainer): unable to access .ssh

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
 
 ARG USER_UID
-RUN if [[ -z "$USER_UID" ]]; then usermod -u "${USER_UID}" vscode; fi
+RUN if [ -n "$USER_UID" ]; then usermod -u "${USER_UID}" vscode; fi
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
     "workspaceMount": "source=${localWorkspaceFolder},target=/workspace/buildzr,type=bind",
     "workspaceFolder": "/workspace/buildzr",
     "mounts": [
-        "source=${env:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,readonly"
+        "source=${env:HOME}/.ssh,target=/home/vscode/.ssh,type=bind"
     ],
     "remoteUser": "vscode",
     "postStartCommand": "chmod 700 /home/vscode/.ssh && chmod 600 /home/vscode/.ssh/*",

--- a/buildzr/__about__.py
+++ b/buildzr/__about__.py
@@ -1,1 +1,1 @@
-VERSION = "0.0.10"
+VERSION = "0.0.11.dev0"


### PR DESCRIPTION
Fix unable to read from the mounted `~/.ssh` file
since because of bad logic handling in Dockerfile
for running the `usermod` command.