### PR TITLE
chore: remove ssh mounting from dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,11 +7,7 @@
     },
     "workspaceMount": "source=${localWorkspaceFolder},target=/workspace/buildzr,type=bind",
     "workspaceFolder": "/workspace/buildzr",
-    "mounts": [
-        "source=${env:HOME}/.ssh,target=/home/vscode/.ssh,type=bind"
-    ],
     "remoteUser": "vscode",
-    "postStartCommand": "chmod 700 /home/vscode/.ssh && chmod 600 /home/vscode/.ssh/*",
     "features": {
         "ghcr.io/rocker-org/devcontainer-features/miniforge:2": {},
         "ghcr.io/devcontainers/features/sshd:1": {


### PR DESCRIPTION
See: https://stackoverflow.com/a/79345067

It seems like for locally running dev container (i.e., not not codespaces), we no longer need to mount local `~/.ssh` directory into the container.

Just use `ssh-agent` and `ssh-add` in the local machine instead before running the dev container.

This works because docker mounts the local ssh socket from the local machine into the container, so the container can use the local ssh keys without needing to mount the entire `~/.ssh` directory.

You can see the mount path by running `echo $SSH_AUTH_SOCK` in the dev container.