### PR TITLE
fix: apply SVG cleanup to render_to_svg_dict() for Jupyter notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ with Workspace('w') as w:
         u = Person('Web Application User')
         webapp = SoftwareSystem('Corporate Web App')
         with webapp:
-            database = Container('database', tags={'db'})
+            database = Container('database')
             api = Container('api')
             api >> ("Reads and writes data from/to", "http/api") >> database
     with Group("Microsoft") as microsoft:
@@ -66,21 +66,19 @@ with Workspace('w') as w:
         description="Web App Container View",
     )
 
-    # Stylize the views.
+    # Stylize the views, and apply AWS theme icons.
 
-    StyleElements(on=['db'], shape='Cylinder')
-
-    # Apply AWS theme icons.
-
-    StyleElements(on=[u], shape='Person', **AWS.USER)
+    StyleElements(on=[u], **AWS.USER)
     StyleElements(on=[api], **AWS.LAMBDA)
     StyleElements(on=[database], **AWS.RDS)
 
     # Export to JSON, PlantUML, or SVG.
 
     w.save()                                  # JSON to {workspace_name}.json
+
+    # Requires `pip install buildzr[export-plantuml]`
     w.save(format='plantuml', path='output/') # PlantUML files
-    w.save(format='svg', path='output/')      # SVG files (requires: pip install buildzr[export-plantuml])
+    w.save(format='svg', path='output/')      # SVG files
 ```
 
 ![Example Software System View](./docs/images/quick_example/web_app_system_context_00.svg)
@@ -92,7 +90,7 @@ Ready to dive in? Check out the [Quick Start Tutorial](https://buildzr.dev/getti
 
 ## Why use `buildzr`?
 
-✅ **Intuitive Pythonic Syntax**: Use Python's context managers (`with` statements) to create nested structures that naturally mirror your architecture's hierarchy. See the [example](#quick-example) below.
+✅ **Intuitive Pythonic Syntax**: Use Python's context managers (`with` statements) to create nested structures that naturally mirror your architecture's hierarchy. See the [example](#quick-example).
 
 ✅ **Programmatic Creation**: Use `buildzr`'s DSL APIs to programmatically create C4 model architecture diagrams. Great for automation!
 

--- a/buildzr/sinks/plantuml_sink.py
+++ b/buildzr/sinks/plantuml_sink.py
@@ -96,6 +96,8 @@ class PlantUmlSink(Sink[PlantUmlSinkConfig]):
         result: dict[str, str] = {}
         for view_key, puml_content in diagrams.items():
             svg_bytes = self._render_to_bytes(puml_content, "svg")
+            # Apply SVG cleanup to remove placeholder characters
+            svg_bytes = self._clean_svg_legend(svg_bytes)
             result[view_key] = svg_bytes.decode('utf-8')
 
         return result

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,9 @@
---8<-- "README.md:1:85"
+--8<-- "README.md:1:83"
 
-![Example Software System View](images/example_system_context_view.png)
-![Example Container View](images/example_container_view.png)
+![Example Software System View](images/quick_example/web_app_system_context_00.svg)
+![Example Container View](images/quick_example/web_app_container_view_00.svg)
 
---8<-- "README.md:89:115"
+--8<-- "README.md:89:113"
 
 <!-- Override README links with docs-relative paths -->
 [Quick Start Tutorial]: getting-started/quick-start.md

--- a/examples/amazon_web_services.ipynb
+++ b/examples/amazon_web_services.ipynb
@@ -13,7 +13,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "source": "from buildzr.__about__ import VERSION\nprint(f\"buildzr version: {VERSION}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -45,114 +52,75 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "with Workspace(\n",
-    "    \"Amazon Web Services Example\",\n",
-    "    description=\"An example AWS deployment architecture\",\n",
-    ") as w:\n",
+    "from buildzr.dsl import (\n",
+    "    Workspace,\n",
+    "    SoftwareSystem,\n",
+    "    Person,\n",
+    "    Container,\n",
+    "    SystemContextView,\n",
+    "    ContainerView,\n",
+    "    desc,\n",
+    "    Group,\n",
+    "    StyleElements,\n",
+    ")\n",
+    "from buildzr.themes import AWS\n",
     "\n",
-    "    user = Person(\"User\", description=\"An ordinary user.\")\n",
+    "with Workspace('w') as w:\n",
     "\n",
-    "    with SoftwareSystem(\"X\") as x:\n",
+    "    # Define your models (architecture elements and their relationships).\n",
     "\n",
-    "        wa = Container(\"Web Application\", technology=\"Java and Spring boot\")\n",
-    "        db = Container(\"Database Schema\")\n",
+    "    with Group(\"My Company\") as my_company:\n",
+    "        u = Person('Web Application User')\n",
+    "        webapp = SoftwareSystem('Corporate Web App')\n",
+    "        with webapp:\n",
+    "            database = Container('database', tags={'db'})\n",
+    "            api = Container('api')\n",
+    "            api >> (\"Reads and writes data from/to\", \"http/api\") >> database\n",
+    "    with Group(\"Microsoft\") as microsoft:\n",
+    "        email_system = SoftwareSystem('Microsoft 365')\n",
     "\n",
-    "        wa >> \"Reads from and writes to\" >> db\n",
+    "    u >> [\n",
+    "        desc(\"Reads and writes email using\") >> email_system,\n",
+    "        desc(\"Create work order using\") >> webapp,\n",
+    "    ]\n",
+    "    webapp >> \"sends notification using\" >> email_system\n",
     "\n",
-    "        with wa:\n",
-    "            api_layer = Component(\"API Layer\")\n",
-    "            db_layer = Component(\"Database Layer\")\n",
-    "\n",
-    "            api_layer >> \"Runs queries/transactions on\" >> db_layer\n",
-    "\n",
-    "    user >> (\"Uses\", \"browser\") >> x\n",
-    "\n",
-    "    with DeploymentEnvironment(\"Live\") as live:\n",
-    "\n",
-    "        dg_region_1 = DeploymentGroup(\"region-1\")\n",
-    "        dg_region_2 = DeploymentGroup(\"region-2\")\n",
-    "\n",
-    "        with DeploymentNode(\"Amazon Web Services\") as aws:\n",
-    "            aws.add_tags(\"Amazon Web Services - Cloud\")\n",
-    "\n",
-    "            with DeploymentNode(\"ap-southeast-1\") as region_ap_southeast_1:\n",
-    "                region_ap_southeast_1.add_tags(\"Amazon Web Services - Region\")\n",
-    "\n",
-    "                dns = InfrastructureNode(\n",
-    "                    \"DNS Router\",\n",
-    "                    description=\"Routes incoming requests based upon domain name.\",\n",
-    "                    technology=\"Route 53\",\n",
-    "                    tags={\"Amazon Web Services - Route 53\"}\n",
-    "                )\n",
-    "\n",
-    "                lb = InfrastructureNode(\n",
-    "                    \"Load Balancer\",\n",
-    "                    description=\"Automatically distributes incoming application traffic.\",\n",
-    "                    technology=\"Elastic Load Balancer\",\n",
-    "                    tags={\"Amazon Web Services - Elastic Load Balancer\"}\n",
-    "                )\n",
-    "\n",
-    "                dns >> (\"Fowards requests to\", \"HTTP\") >> lb\n",
-    "\n",
-    "                with DeploymentNode(\"Autoscaling Group\", tags={\"Amazon Web Services - Autoscaling Group\"}) as asg:\n",
-    "                    with DeploymentNode(\"Amazon EC2 - Ubuntu Server\", tags={\"Amazon Web Services - EC2 Instance\"}):\n",
-    "                        lb >> \"Forwards requests to\" >> ContainerInstance(wa, deployment_groups=[dg_region_1])\n",
-    "\n",
-    "                with DeploymentNode(\"Amazon RDS\", tags={\"Amazon Web Services - RDS Instance\"}) as rds:\n",
-    "                    with DeploymentNode(\"MySQL\", tags={\"Amazon Web Services - RDS MySQL instance\"}):\n",
-    "                        database_instance = ContainerInstance(db, deployment_groups=[dg_region_1])\n",
-    "\n",
-    "            with DeploymentNode(\"us-east-1\") as region_us_east_1:\n",
-    "                region_us_east_1.add_tags(\"Amazon Web Services - Region\")\n",
-    "\n",
-    "                dns = InfrastructureNode(\n",
-    "                    \"DNS Router\",\n",
-    "                    description=\"Routes incoming requests based upon domain name.\",\n",
-    "                    technology=\"Route 53\",\n",
-    "                    tags={\"Amazon Web Services - Route 53\"}\n",
-    "                )\n",
-    "\n",
-    "                lb = InfrastructureNode(\n",
-    "                    \"Load Balancer\",\n",
-    "                    description=\"Automatically distributes incoming application traffic.\",\n",
-    "                    technology=\"Elastic Load Balancer\",\n",
-    "                    tags={\"Amazon Web Services - Elastic Load Balancer\"}\n",
-    "                )\n",
-    "\n",
-    "                dns >> (\"Fowards requests to\", \"HTTP\") >> lb\n",
-    "\n",
-    "                with DeploymentNode(\"Autoscaling Group\", tags={\"Amazon Web Services - Autoscaling Group\"}) as asg:\n",
-    "                    with DeploymentNode(\"Amazon EC2 - Ubuntu Server\", tags={\"Amazon Web Services - EC2 Instance\"}):\n",
-    "                        lb >> \"Forwards requests to\" >> ContainerInstance(wa, deployment_groups=[dg_region_2])\n",
-    "\n",
-    "                with DeploymentNode(\"Amazon RDS\", tags={\"Amazon Web Services - RDS Instance\"}) as rds:\n",
-    "                    with DeploymentNode(\"MySQL\", tags={\"Amazon Web Services - RDS MySQL instance\"}):\n",
-    "                        database_instance = ContainerInstance(db, deployment_groups=[dg_region_2])\n",
+    "    # Define the views.\n",
     "\n",
     "    SystemContextView(\n",
-    "        software_system_selector=x,\n",
-    "        key='x_context_00',\n",
-    "        description=\"System context of X\",\n",
-    "    )\n",
-    "\n",
-    "    DeploymentView(\n",
-    "        environment=live,\n",
-    "        key='aws-deployment-view',\n",
-    "        software_system_selector=x,\n",
-    "        title=\"Amazon Web Services Deployment\",\n",
-    "        description=\"Deployment view of the web application on AWS\",\n",
+    "        software_system_selector=webapp,\n",
+    "        key='web_app_system_context_00',\n",
+    "        description=\"Web App System Context\",\n",
     "        auto_layout='lr',\n",
     "    )\n",
     "\n",
-    "    StyleElements(on=['Element'], background='#ffffff')\n",
-    "    StyleElements(on=['Container'], background='#ffffff')\n",
-    "    StyleElements(on=[wa], background='#ffffff')\n",
-    "    StyleElements(on=[user], shape='Person')\n",
-    "    StyleElements(on=[db], shape='Cylinder')"
+    "    ContainerView(\n",
+    "        software_system_selector=webapp,\n",
+    "        key='web_app_container_view_00',\n",
+    "        auto_layout='lr',\n",
+    "        description=\"Web App Container View\",\n",
+    "    )\n",
+    "\n",
+    "    # Stylize the views.\n",
+    "\n",
+    "    StyleElements(on=['db'], shape='Cylinder')\n",
+    "\n",
+    "    # Apply AWS theme icons.\n",
+    "\n",
+    "    StyleElements(on=[u], shape='Person', **AWS.USER)\n",
+    "    StyleElements(on=[api], **AWS.LAMBDA)\n",
+    "    StyleElements(on=[database], **AWS.RDS)\n",
+    "\n",
+    "    # Export to JSON, PlantUML, or SVG.\n",
+    "\n",
+    "    w.save()                                  # JSON to {workspace_name}.json\n",
+    "\n",
+    "    w.save(format='plantuml', path='output/') # PlantUML files\n",
+    "    w.save(format='svg', path='output/')      # SVG files"
    ]
   },
   {
@@ -166,19 +134,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Workspace: Amazon Web Services Example\n",
-      "Description: An example AWS deployment architecture\n",
-      "Number of views: 2\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Get workspace as dictionary\n",
     "data = w.to_dict()\n",
@@ -189,339 +147,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'id': 1,\n",
-       " 'name': 'Amazon Web Services Example',\n",
-       " 'description': 'An example AWS deployment architecture',\n",
-       " 'model': {'people': [{'id': '1',\n",
-       "    'name': 'User',\n",
-       "    'description': 'An ordinary user.',\n",
-       "    'tags': 'Element,buildzr-styleelements-0b2892fe79dc4b01832bec8cf485fd49,Person',\n",
-       "    'location': 'Unspecified',\n",
-       "    'properties': {},\n",
-       "    'relationships': [{'id': '9',\n",
-       "      'description': 'Uses',\n",
-       "      'tags': 'Relationship',\n",
-       "      'sourceId': '1',\n",
-       "      'destinationId': '2',\n",
-       "      'technology': 'browser'}]}],\n",
-       "  'softwareSystems': [{'id': '2',\n",
-       "    'name': 'X',\n",
-       "    'description': '',\n",
-       "    'location': 'Unspecified',\n",
-       "    'tags': 'Element,Software System',\n",
-       "    'containers': [{'id': '3',\n",
-       "      'name': 'Web Application',\n",
-       "      'description': '',\n",
-       "      'technology': 'Java and Spring boot',\n",
-       "      'tags': 'Element,buildzr-styleelements-528158d949d34a899dcac10132f2aa39,Container',\n",
-       "      'components': [{'id': '6',\n",
-       "        'name': 'API Layer',\n",
-       "        'description': '',\n",
-       "        'technology': '',\n",
-       "        'tags': 'Element,Component',\n",
-       "        'properties': {},\n",
-       "        'relationships': [{'id': '8',\n",
-       "          'description': 'Runs queries/transactions on',\n",
-       "          'tags': 'Relationship',\n",
-       "          'sourceId': '6',\n",
-       "          'destinationId': '7',\n",
-       "          'technology': ''}]},\n",
-       "       {'id': '7',\n",
-       "        'name': 'Database Layer',\n",
-       "        'description': '',\n",
-       "        'technology': '',\n",
-       "        'tags': 'Element,Component',\n",
-       "        'properties': {},\n",
-       "        'relationships': []}],\n",
-       "      'properties': {},\n",
-       "      'relationships': [{'id': '5',\n",
-       "        'description': 'Reads from and writes to',\n",
-       "        'tags': 'Relationship',\n",
-       "        'sourceId': '3',\n",
-       "        'destinationId': '4',\n",
-       "        'technology': ''}]},\n",
-       "     {'id': '4',\n",
-       "      'name': 'Database Schema',\n",
-       "      'description': '',\n",
-       "      'technology': '',\n",
-       "      'tags': 'Element,buildzr-styleelements-a10d9e75db0c40a292b1d7ca315ccce3,Container',\n",
-       "      'components': [],\n",
-       "      'properties': {},\n",
-       "      'relationships': []}],\n",
-       "    'properties': {},\n",
-       "    'relationships': [],\n",
-       "    'documentation': {}}],\n",
-       "  'deploymentNodes': [{'id': '10',\n",
-       "    'name': 'Amazon Web Services',\n",
-       "    'description': '',\n",
-       "    'technology': '',\n",
-       "    'environment': 'Live',\n",
-       "    'instances': '1',\n",
-       "    'tags': 'Deployment Node,Element,Amazon Web Services - Cloud',\n",
-       "    'children': [{'id': '11',\n",
-       "      'name': 'ap-southeast-1',\n",
-       "      'description': '',\n",
-       "      'technology': '',\n",
-       "      'environment': 'Live',\n",
-       "      'instances': '1',\n",
-       "      'tags': 'Deployment Node,Element,Amazon Web Services - Region',\n",
-       "      'children': [{'id': '15',\n",
-       "        'name': 'Autoscaling Group',\n",
-       "        'description': '',\n",
-       "        'technology': '',\n",
-       "        'environment': 'Live',\n",
-       "        'instances': '1',\n",
-       "        'tags': 'Deployment Node,Element,Amazon Web Services - Autoscaling Group',\n",
-       "        'children': [{'id': '16',\n",
-       "          'name': 'Amazon EC2 - Ubuntu Server',\n",
-       "          'description': '',\n",
-       "          'technology': '',\n",
-       "          'environment': 'Live',\n",
-       "          'instances': '1',\n",
-       "          'tags': 'Deployment Node,Element,Amazon Web Services - EC2 Instance',\n",
-       "          'children': [],\n",
-       "          'infrastructureNodes': [],\n",
-       "          'softwareSystemInstances': [],\n",
-       "          'containerInstances': [{'id': '18',\n",
-       "            'containerId': '3',\n",
-       "            'environment': 'Live',\n",
-       "            'tags': 'Container Instance',\n",
-       "            'relationships': [{'id': '33',\n",
-       "              'description': 'Reads from and writes to',\n",
-       "              'tags': 'Relationship',\n",
-       "              'sourceId': '18',\n",
-       "              'destinationId': '21',\n",
-       "              'technology': '',\n",
-       "              'linkedRelationshipId': '5'}],\n",
-       "            'deploymentGroups': ['region-1']}]}],\n",
-       "        'infrastructureNodes': [],\n",
-       "        'softwareSystemInstances': [],\n",
-       "        'containerInstances': []},\n",
-       "       {'id': '19',\n",
-       "        'name': 'Amazon RDS',\n",
-       "        'description': '',\n",
-       "        'technology': '',\n",
-       "        'environment': 'Live',\n",
-       "        'instances': '1',\n",
-       "        'tags': 'Deployment Node,Element,Amazon Web Services - RDS Instance',\n",
-       "        'children': [{'id': '20',\n",
-       "          'name': 'MySQL',\n",
-       "          'description': '',\n",
-       "          'technology': '',\n",
-       "          'environment': 'Live',\n",
-       "          'instances': '1',\n",
-       "          'tags': 'Deployment Node,Element,Amazon Web Services - RDS MySQL instance',\n",
-       "          'children': [],\n",
-       "          'infrastructureNodes': [],\n",
-       "          'softwareSystemInstances': [],\n",
-       "          'containerInstances': [{'id': '21',\n",
-       "            'containerId': '4',\n",
-       "            'environment': 'Live',\n",
-       "            'tags': 'Container Instance',\n",
-       "            'deploymentGroups': ['region-1']}]}],\n",
-       "        'infrastructureNodes': [],\n",
-       "        'softwareSystemInstances': [],\n",
-       "        'containerInstances': []}],\n",
-       "      'infrastructureNodes': [{'id': '12',\n",
-       "        'name': 'DNS Router',\n",
-       "        'description': 'Routes incoming requests based upon domain name.',\n",
-       "        'technology': 'Route 53',\n",
-       "        'environment': 'Live',\n",
-       "        'tags': 'Element,Amazon Web Services - Route 53,Infrastructure Node',\n",
-       "        'properties': {},\n",
-       "        'relationships': [{'id': '14',\n",
-       "          'description': 'Fowards requests to',\n",
-       "          'tags': 'Relationship',\n",
-       "          'sourceId': '12',\n",
-       "          'destinationId': '13',\n",
-       "          'technology': 'HTTP'}]},\n",
-       "       {'id': '13',\n",
-       "        'name': 'Load Balancer',\n",
-       "        'description': 'Automatically distributes incoming application traffic.',\n",
-       "        'technology': 'Elastic Load Balancer',\n",
-       "        'environment': 'Live',\n",
-       "        'tags': 'Element,Amazon Web Services - Elastic Load Balancer,Infrastructure Node',\n",
-       "        'properties': {},\n",
-       "        'relationships': [{'id': '17',\n",
-       "          'description': 'Forwards requests to',\n",
-       "          'tags': 'Relationship',\n",
-       "          'sourceId': '13',\n",
-       "          'destinationId': '18',\n",
-       "          'technology': ''}]}],\n",
-       "      'softwareSystemInstances': [],\n",
-       "      'containerInstances': []},\n",
-       "     {'id': '22',\n",
-       "      'name': 'us-east-1',\n",
-       "      'description': '',\n",
-       "      'technology': '',\n",
-       "      'environment': 'Live',\n",
-       "      'instances': '1',\n",
-       "      'tags': 'Deployment Node,Element,Amazon Web Services - Region',\n",
-       "      'children': [{'id': '26',\n",
-       "        'name': 'Autoscaling Group',\n",
-       "        'description': '',\n",
-       "        'technology': '',\n",
-       "        'environment': 'Live',\n",
-       "        'instances': '1',\n",
-       "        'tags': 'Deployment Node,Element,Amazon Web Services - Autoscaling Group',\n",
-       "        'children': [{'id': '27',\n",
-       "          'name': 'Amazon EC2 - Ubuntu Server',\n",
-       "          'description': '',\n",
-       "          'technology': '',\n",
-       "          'environment': 'Live',\n",
-       "          'instances': '1',\n",
-       "          'tags': 'Deployment Node,Element,Amazon Web Services - EC2 Instance',\n",
-       "          'children': [],\n",
-       "          'infrastructureNodes': [],\n",
-       "          'softwareSystemInstances': [],\n",
-       "          'containerInstances': [{'id': '29',\n",
-       "            'containerId': '3',\n",
-       "            'environment': 'Live',\n",
-       "            'tags': 'Container Instance',\n",
-       "            'relationships': [{'id': '34',\n",
-       "              'description': 'Reads from and writes to',\n",
-       "              'tags': 'Relationship',\n",
-       "              'sourceId': '29',\n",
-       "              'destinationId': '32',\n",
-       "              'technology': '',\n",
-       "              'linkedRelationshipId': '5'}],\n",
-       "            'deploymentGroups': ['region-2']}]}],\n",
-       "        'infrastructureNodes': [],\n",
-       "        'softwareSystemInstances': [],\n",
-       "        'containerInstances': []},\n",
-       "       {'id': '30',\n",
-       "        'name': 'Amazon RDS',\n",
-       "        'description': '',\n",
-       "        'technology': '',\n",
-       "        'environment': 'Live',\n",
-       "        'instances': '1',\n",
-       "        'tags': 'Deployment Node,Element,Amazon Web Services - RDS Instance',\n",
-       "        'children': [{'id': '31',\n",
-       "          'name': 'MySQL',\n",
-       "          'description': '',\n",
-       "          'technology': '',\n",
-       "          'environment': 'Live',\n",
-       "          'instances': '1',\n",
-       "          'tags': 'Deployment Node,Element,Amazon Web Services - RDS MySQL instance',\n",
-       "          'children': [],\n",
-       "          'infrastructureNodes': [],\n",
-       "          'softwareSystemInstances': [],\n",
-       "          'containerInstances': [{'id': '32',\n",
-       "            'containerId': '4',\n",
-       "            'environment': 'Live',\n",
-       "            'tags': 'Container Instance',\n",
-       "            'deploymentGroups': ['region-2']}]}],\n",
-       "        'infrastructureNodes': [],\n",
-       "        'softwareSystemInstances': [],\n",
-       "        'containerInstances': []}],\n",
-       "      'infrastructureNodes': [{'id': '23',\n",
-       "        'name': 'DNS Router',\n",
-       "        'description': 'Routes incoming requests based upon domain name.',\n",
-       "        'technology': 'Route 53',\n",
-       "        'environment': 'Live',\n",
-       "        'tags': 'Element,Amazon Web Services - Route 53,Infrastructure Node',\n",
-       "        'properties': {},\n",
-       "        'relationships': [{'id': '25',\n",
-       "          'description': 'Fowards requests to',\n",
-       "          'tags': 'Relationship',\n",
-       "          'sourceId': '23',\n",
-       "          'destinationId': '24',\n",
-       "          'technology': 'HTTP'}]},\n",
-       "       {'id': '24',\n",
-       "        'name': 'Load Balancer',\n",
-       "        'description': 'Automatically distributes incoming application traffic.',\n",
-       "        'technology': 'Elastic Load Balancer',\n",
-       "        'environment': 'Live',\n",
-       "        'tags': 'Element,Amazon Web Services - Elastic Load Balancer,Infrastructure Node',\n",
-       "        'properties': {},\n",
-       "        'relationships': [{'id': '28',\n",
-       "          'description': 'Forwards requests to',\n",
-       "          'tags': 'Relationship',\n",
-       "          'sourceId': '24',\n",
-       "          'destinationId': '29',\n",
-       "          'technology': ''}]}],\n",
-       "      'softwareSystemInstances': [],\n",
-       "      'containerInstances': []}],\n",
-       "    'infrastructureNodes': [],\n",
-       "    'softwareSystemInstances': [],\n",
-       "    'containerInstances': []}],\n",
-       "  'properties': {'structurizr.groupSeparator': '/'}},\n",
-       " 'views': {'systemContextViews': [{'key': 'x_context_00',\n",
-       "    'order': 1,\n",
-       "    'description': 'System context of X',\n",
-       "    'softwareSystemId': '2',\n",
-       "    'automaticLayout': {'implementation': 'Graphviz',\n",
-       "     'rankDirection': 'TopBottom',\n",
-       "     'rankSeparation': 300,\n",
-       "     'nodeSeparation': 300,\n",
-       "     'edgeSeparation': 0,\n",
-       "     'vertices': False,\n",
-       "     'applied': False},\n",
-       "    'enterpriseBoundaryVisible': True,\n",
-       "    'elements': [{'id': '1', 'x': 0, 'y': 0}, {'id': '2', 'x': 0, 'y': 0}],\n",
-       "    'relationships': [{'id': '9'}]}],\n",
-       "  'deploymentViews': [{'key': 'aws-deployment-view',\n",
-       "    'title': 'Amazon Web Services Deployment',\n",
-       "    'description': 'Deployment view of the web application on AWS',\n",
-       "    'softwareSystemId': '2',\n",
-       "    'environment': 'Live',\n",
-       "    'automaticLayout': {'implementation': 'Graphviz',\n",
-       "     'rankDirection': 'LeftRight',\n",
-       "     'rankSeparation': 300,\n",
-       "     'nodeSeparation': 300,\n",
-       "     'edgeSeparation': 0,\n",
-       "     'vertices': False},\n",
-       "    'elements': [{'id': '10', 'x': 0, 'y': 0},\n",
-       "     {'id': '11', 'x': 0, 'y': 0},\n",
-       "     {'id': '12', 'x': 0, 'y': 0},\n",
-       "     {'id': '13', 'x': 0, 'y': 0},\n",
-       "     {'id': '15', 'x': 0, 'y': 0},\n",
-       "     {'id': '16', 'x': 0, 'y': 0},\n",
-       "     {'id': '18', 'x': 0, 'y': 0},\n",
-       "     {'id': '19', 'x': 0, 'y': 0},\n",
-       "     {'id': '20', 'x': 0, 'y': 0},\n",
-       "     {'id': '21', 'x': 0, 'y': 0},\n",
-       "     {'id': '22', 'x': 0, 'y': 0},\n",
-       "     {'id': '23', 'x': 0, 'y': 0},\n",
-       "     {'id': '24', 'x': 0, 'y': 0},\n",
-       "     {'id': '26', 'x': 0, 'y': 0},\n",
-       "     {'id': '27', 'x': 0, 'y': 0},\n",
-       "     {'id': '29', 'x': 0, 'y': 0},\n",
-       "     {'id': '30', 'x': 0, 'y': 0},\n",
-       "     {'id': '31', 'x': 0, 'y': 0},\n",
-       "     {'id': '32', 'x': 0, 'y': 0}],\n",
-       "    'relationships': [{'id': '14'},\n",
-       "     {'id': '17'},\n",
-       "     {'id': '33'},\n",
-       "     {'id': '25'},\n",
-       "     {'id': '28'},\n",
-       "     {'id': '34'}]}],\n",
-       "  'configuration': {'styles': {'elements': [{'tag': 'Element',\n",
-       "      'background': '#ffffff'},\n",
-       "     {'tag': 'Container', 'background': '#ffffff'},\n",
-       "     {'tag': 'buildzr-styleelements-528158d949d34a899dcac10132f2aa39',\n",
-       "      'background': '#ffffff'},\n",
-       "     {'tag': 'buildzr-styleelements-0b2892fe79dc4b01832bec8cf485fd49',\n",
-       "      'shape': 'Person'},\n",
-       "     {'tag': 'buildzr-styleelements-a10d9e75db0c40a292b1d7ca315ccce3',\n",
-       "      'shape': 'Cylinder'}]},\n",
-       "   'branding': {},\n",
-       "   'terminology': {}}},\n",
-       " 'documentation': {},\n",
-       " 'configuration': {'scope': 'SoftwareSystem'}}"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "w.to_dict()"
    ]
@@ -536,69 +164,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "OpenJDK 64-Bit Server VM warning: Unable to get SVE vector length on this system. Disabling SVE. Specify -XX:UseSVE=0 to shun this warning.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "JVM started with JARs: /workspace/buildzr/buildzr/jars/structurizr-export.jar, /workspace/buildzr/buildzr/jars/structurizr-core.jar, /workspace/buildzr/buildzr/jars/commons-logging.jar, /workspace/buildzr/buildzr/jars/plantuml.jar\n",
-      "=== x_context_00 ===\n",
-      "@startuml\n",
-      "set separator none\n",
-      "title X - System Context\n",
-      "\n",
-      "top to bottom direction\n",
-      "\n",
-      "!include <C4/C4>\n",
-      "!include <C4/C4_Context>\n",
-      "\n",
-      "Person(User, \"User\", $descr=\"An ordinary user.\", $tags=\"\", $link=\"\")\n",
-      "System(X, \"X\", $descr=\"\", $tags=\"\", $link=\"\")\n",
-      "\n",
-      "Rel(User, X, \"Uses\", $techn=\"browser\", $tags=\"\", $link=\"\")\n",
-      "\n",
-      "SHOW_LEGEND(true)\n",
-      "@enduml\n",
-      "\n",
-      "=== aws-deployment-view ===\n",
-      "@startuml\n",
-      "set separator none\n",
-      "title Amazon Web Services Deployment\n",
-      "\n",
-      "top to bottom direction\n",
-      "\n",
-      "!include <C4/C4>\n",
-      "!include <C4/C4_Context>\n",
-      "!include <C4/C4_Container>\n",
-      "!include <C4/C4_Deployment>\n",
-      "\n",
-      "Deployment_Node(Default.AmazonWebServices, \"Amazon Web Services\", $type=\"\", $descr=\"\", $tags=\"\", $link=\"\") {\n",
-      "  Deployment_Node(Default.AmazonWebServices.useast1, \"us-east-1\", $type=\"\", $descr=\"\", $tags=\"\", $link=\"\") {\n",
-      "    Deployment_Node(Default.AmazonWebServices.useast1.AutoscalingGroup, \"Autoscaling Group\",...\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Get PlantUML source for all views\n",
-    "puml = w.to_plantuml_string()\n",
-    "for view_key, content in puml.items():\n",
-    "    print(f\"=== {view_key} ===\")\n",
-    "    print(content[:500] + \"...\" if len(content) > 500 else content)\n",
-    "    print()"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -609,63 +174,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<h3>x_context_00</h3>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "image/svg+xml": [
-       "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" contentStyleType=\"text/css\" height=\"390px\" preserveAspectRatio=\"none\" style=\"width:179px;height:390px;background:#FFFFFF;\" version=\"1.1\" viewBox=\"0 0 179 390\" width=\"179px\" zoomAndPan=\"magnify\"><title>X - System Context</title><defs/><g><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"151.3135\" x=\"10\" y=\"22.9951\">X - System Context</text><!--entity User--><g id=\"elem_User\"><rect fill=\"#08427B\" height=\"119.2188\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#073B6F;stroke-width:0.5;\" width=\"140.9277\" x=\"22.6929\" y=\"44.2969\"/><image height=\"48\" width=\"48\" x=\"69.1567\" xlink:href=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAACMElEQVR4Xu2YvUrFQBCFb+kj+Ai+gq3Y2PgA+gCCtZ2V2AhqaSNiqY1gYWMjaCvXykoEKy21sLCNfELgMscksz8mWfDAB3Kuye7sTmYnmcwtbU9KRozSECOVla3T6uTqvrqZPlcPT68/XNw+VtvH19XC+sGe/f9UxIhl8/Cy+vj8qrpEYIsbR1N7fSxihDK/urvMKoeKHbH3ikGMEJi8Z9WbtH92lxyEGCHErLwVqWfvG4IYXkiBXGIn7f29iOGBAe0kUkTVsmN4EcMD255bdgwvYnigFOYW54cdx4MYHlIqT5Niy6oYHuzgORRbUsXwYAfPoV4DeHl7t+MnK/Y8EMMDzVlu9foQ5y6jFAU7hhcxvOSsRLH5D2J4KbqVqMlxoK3tnEevPogRAiuXUpFiD69ZxIghZidSV75GjFiYkGc3KMEpOW8RIxXed0kNJsrOAO0ypTfnxGvEKA0xSkMMD3zfIedJFQ4hCPlUwrX1daQWbURseonRBhNue1D5rc53JkVQwN9c21Wt+D20JxLjN7hpztahSwTi3RExLDlbhhCxm55PkWLMkrvrDBW73rUTYtSQu/aGQ4h0snNzBdD1wPWptrZDDBjL6tfiebBzbA2AUjg2NT3QYkBbrR9KTS/9YoC9eAxqeu0UI/eH21yiu7VzLSqApnIqxn8Af6TiA3A/A9Bn5+lV0xcMMWDoJs6qrakTo4a6OwZxqLa97YkxC1HzMkMzNQRtE3cFUAJilMY3OGTNL0NDLqIAAAAASUVORK5CYII=\" y=\"54.2969\"/><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"41.2578\" x=\"72.5278\" y=\"117.1484\">User</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"90.9316\" y=\"133.917\"> </text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"18.4502\" x=\"32.6929\" y=\"150.2139\">An</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"51.1431\" y=\"150.2139\"> </text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"58.5908\" x=\"55.5933\" y=\"150.2139\">ordinary</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"114.1841\" y=\"150.2139\"> </text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"34.9863\" x=\"118.6343\" y=\"150.2139\">user.</text></g><!--entity X--><g id=\"elem_X\"><rect fill=\"#1168BD\" height=\"38.625\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#3C7FC0;stroke-width:0.5;\" width=\"32.3359\" x=\"77.1929\" y=\"252.2969\"/><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"12.3359\" x=\"87.1929\" y=\"277.1484\">X</text></g><!--link User to X--><g id=\"link_User_X\"><path d=\"M93.1929,163.3269 C93.1929,194.4969 93.1929,222.7369 93.1929,244.1669 \" fill=\"none\" id=\"User-to-X\" style=\"stroke:#666666;stroke-width:1;\"/><polygon fill=\"#666666\" points=\"93.1929,252.1669,96.1929,244.1669,90.1929,244.1669,93.1929,252.1669\" style=\"stroke:#666666;stroke-width:1;\"/><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"32.168\" x=\"106.9282\" y=\"205.4355\">Uses</text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"57.6387\" x=\"94.1929\" y=\"219.4043\">[browser]</text></g><rect fill=\"none\" height=\"16.2969\" style=\"stroke:none;stroke-width:1;\" width=\"94.3936\" x=\"44.2271\" y=\"314.9219\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"57.9209\" x=\"44.2271\" y=\"327.917\">Legend</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"107.022\" y=\"327.917\"> </text><rect fill=\"#08427B\" height=\"16.2969\" style=\"stroke:none;stroke-width:1;\" width=\"94.3936\" x=\"44.2271\" y=\"331.2188\"/><text fill=\"#073B6F\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"7.7041\" x=\"48.6772\" y=\"344.2139\">▯</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"56.3813\" y=\"344.2139\"> </text><image height=\"12\" width=\"12\" x=\"60.8315\" xlink:href=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAApklEQVR4XmPgcKpmQMfRjcsb/CoWNqCLgzCGwH80gC6Pwjl17RG6+v9T1h47gFPD95+/0dX/33v2DootKBriW1Y2oGvQjesPxKkBhDuW7D8AUxzfunIiujwKRzWyO8ksdXIxjG+XPaNBNqgNuw3IzkAHIL+haNh67MZndEXooGXh3kVwDeiS2MCtx6/BtoA1/P7zF10eA5y69hihAYQNkyY24MMwdQBvKDvWFDAX9QAAAABJRU5ErkJggg==\" y=\"335.5156\"/><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"47.9883\" x=\"81.7319\" y=\"344.2139\">person</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"134.1704\" y=\"344.2139\"> </text><rect fill=\"#1168BD\" height=\"16.2969\" style=\"stroke:none;stroke-width:1;\" width=\"94.3936\" x=\"44.2271\" y=\"347.5156\"/><text fill=\"#3C7FC0\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"7.7041\" x=\"48.6772\" y=\"360.5107\">▯</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"56.3813\" y=\"360.5107\"> </text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"50.6133\" x=\"65.2817\" y=\"360.5107\">system</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"120.3452\" y=\"360.5107\"> </text><line style=\"stroke:none;stroke-width:1;\" x1=\"44.2271\" x2=\"138.6206\" y1=\"314.9219\" y2=\"314.9219\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"44.2271\" x2=\"138.6206\" y1=\"331.2188\" y2=\"331.2188\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"44.2271\" x2=\"138.6206\" y1=\"347.5156\" y2=\"347.5156\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"44.2271\" x2=\"138.6206\" y1=\"363.8125\" y2=\"363.8125\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"44.2271\" x2=\"44.2271\" y1=\"314.9219\" y2=\"363.8125\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"138.6206\" x2=\"138.6206\" y1=\"314.9219\" y2=\"363.8125\"/><!--SRC=[TKvDQy9W3BxdLsGlExIWsyMZ5QIA7iOsBCFUfBP1Nwo9v4tP-k_NhZt8s4vvoFCPo33GhT32H9652SnRJPZZ5BCs65qn5JRwCW2J6vhWKSpaYfLNAiqB0pnuBkkc8fodi-TqjlZzE8mH2u1tqY0SVGJI2Rh-k0a-LXHAJToIKRJoN6YBJKSzzPmLfv2u7jMUBnsAOHWMvLr2VcV_HmqxgiV2VEWCFqegpvoueyhdkE8lRxPzsnzUrflrwoeoRIZ-1W00]--></g></svg>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.SVG object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<h3>aws-deployment-view</h3>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "image/svg+xml": [
-       "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" contentStyleType=\"text/css\" height=\"873px\" preserveAspectRatio=\"none\" style=\"width:1125px;height:873px;background:#FFFFFF;\" version=\"1.1\" viewBox=\"0 0 1125 873\" width=\"1125px\" zoomAndPan=\"magnify\"><title>Amazon Web Services Deployment</title><defs/><g><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"274.1416\" x=\"418.4292\" y=\"22.9951\">Amazon Web Services Deployment</text><!--cluster Default.AmazonWebServices--><g id=\"cluster_Default.AmazonWebServices\"><rect fill=\"#FFFFFF\" height=\"729\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#A2A2A2;stroke-width:1;\" width=\"1112\" x=\"7\" y=\"44.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"198.6797\" x=\"463.6602\" y=\"61.1484\">Amazon Web Services</text></g><!--cluster Default.AmazonWebServices.useast1--><g id=\"cluster_Default.AmazonWebServices.useast1\"><rect fill=\"#FFFFFF\" height=\"660\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#A2A2A2;stroke-width:1;\" width=\"520\" x=\"575\" y=\"89.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"84.1484\" x=\"792.9258\" y=\"106.1484\">us-east-1</text></g><!--cluster Default.AmazonWebServices.useast1.AutoscalingGroup--><g id=\"cluster_Default.AmazonWebServices.useast1.AutoscalingGroup\"><rect fill=\"#FFFFFF\" height=\"175\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#A2A2A2;stroke-width:1;\" width=\"323\" x=\"599\" y=\"550.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"166.4609\" x=\"677.2695\" y=\"567.1484\">Autoscaling Group</text></g><!--cluster Default.AmazonWebServices.useast1.AutoscalingGroup.AmazonEC2UbuntuServer--><g id=\"cluster_Default.AmazonWebServices.useast1.AutoscalingGroup.AmazonEC2UbuntuServer\"><rect fill=\"#FFFFFF\" height=\"106\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#A2A2A2;stroke-width:1;\" width=\"275\" x=\"623\" y=\"595.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"259.9766\" x=\"630.5117\" y=\"612.1484\">Amazon EC2 - Ubuntu Server</text></g><!--cluster Default.AmazonWebServices.useast1.AmazonRDS--><g id=\"cluster_Default.AmazonWebServices.useast1.AmazonRDS\"><rect fill=\"#FFFFFF\" height=\"170\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#A2A2A2;stroke-width:1;\" width=\"262\" x=\"809\" y=\"134.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"114.2422\" x=\"882.8789\" y=\"151.1484\">Amazon RDS</text></g><!--cluster Default.AmazonWebServices.useast1.AmazonRDS.MySQL--><g id=\"cluster_Default.AmazonWebServices.useast1.AmazonRDS.MySQL\"><rect fill=\"#FFFFFF\" height=\"101\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#A2A2A2;stroke-width:1;\" width=\"214\" x=\"833\" y=\"179.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"61.6719\" x=\"909.1641\" y=\"196.1484\">MySQL</text></g><!--cluster Default.AmazonWebServices.apsoutheast1--><g id=\"cluster_Default.AmazonWebServices.apsoutheast1\"><rect fill=\"#FFFFFF\" height=\"660\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#A2A2A2;stroke-width:1;\" width=\"520\" x=\"31\" y=\"89.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"136.4297\" x=\"222.7852\" y=\"106.1484\">ap-southeast-1</text></g><!--cluster Default.AmazonWebServices.apsoutheast1.AmazonRDS--><g id=\"cluster_Default.AmazonWebServices.apsoutheast1.AmazonRDS\"><rect fill=\"#FFFFFF\" height=\"170\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#A2A2A2;stroke-width:1;\" width=\"262\" x=\"265\" y=\"134.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"114.2422\" x=\"338.8789\" y=\"151.1484\">Amazon RDS</text></g><!--cluster Default.AmazonWebServices.apsoutheast1.AmazonRDS.MySQL--><g id=\"cluster_Default.AmazonWebServices.apsoutheast1.AmazonRDS.MySQL\"><rect fill=\"#FFFFFF\" height=\"101\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#A2A2A2;stroke-width:1;\" width=\"214\" x=\"289\" y=\"179.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"61.6719\" x=\"365.1641\" y=\"196.1484\">MySQL</text></g><!--cluster Default.AmazonWebServices.apsoutheast1.AutoscalingGroup--><g id=\"cluster_Default.AmazonWebServices.apsoutheast1.AutoscalingGroup\"><rect fill=\"#FFFFFF\" height=\"175\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#A2A2A2;stroke-width:1;\" width=\"323\" x=\"55\" y=\"550.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"166.4609\" x=\"133.2695\" y=\"567.1484\">Autoscaling Group</text></g><!--cluster Default.AmazonWebServices.apsoutheast1.AutoscalingGroup.AmazonEC2UbuntuServer--><g id=\"cluster_Default.AmazonWebServices.apsoutheast1.AutoscalingGroup.AmazonEC2UbuntuServer\"><rect fill=\"#FFFFFF\" height=\"106\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#A2A2A2;stroke-width:1;\" width=\"275\" x=\"79\" y=\"595.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"259.9766\" x=\"86.5117\" y=\"612.1484\">Amazon EC2 - Ubuntu Server</text></g><!--entity Default.AmazonWebServices.useast1.DNSRouter--><g id=\"elem_Default.AmazonWebServices.useast1.DNSRouter\"><rect fill=\"#FFFFFF\" height=\"117.7813\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#A2A2A2;stroke-width:0.5;\" width=\"202.5947\" x=\"590.5\" y=\"181.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"38.1953\" x=\"639.3677\" y=\"206.1484\">DNS</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"5.5703\" x=\"677.563\" y=\"206.1484\"> </text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"61.0938\" x=\"683.1333\" y=\"206.1484\">Router</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"12\" lengthAdjust=\"spacing\" textLength=\"40.0547\" x=\"659.8872\" y=\"221.0605\">[Route</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"12\" lengthAdjust=\"spacing\" textLength=\"3.8145\" x=\"699.9419\" y=\"221.0605\"> </text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"12\" lengthAdjust=\"spacing\" textLength=\"19.9512\" x=\"703.7563\" y=\"221.0605\">53]</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"689.5723\" y=\"236.8857\"> </text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"48.5625\" x=\"600.5\" y=\"253.1826\">Routes</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"649.0625\" y=\"253.1826\"> </text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"64.3125\" x=\"653.5127\" y=\"253.1826\">incoming</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"717.8252\" y=\"253.1826\"> </text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"60.8193\" x=\"722.2754\" y=\"253.1826\">requests</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"42.2598\" x=\"670.6675\" y=\"269.4795\">based</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"35.1982\" x=\"621.4556\" y=\"285.7764\">upon</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"656.6538\" y=\"285.7764\"> </text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"52.4316\" x=\"661.104\" y=\"285.7764\">domain</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"713.5356\" y=\"285.7764\"> </text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"44.1533\" x=\"717.9858\" y=\"285.7764\">name.</text></g><!--entity Default.AmazonWebServices.useast1.LoadBalancer--><g id=\"elem_Default.AmazonWebServices.useast1.LoadBalancer\"><rect fill=\"#FFFFFF\" height=\"101.4844\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#A2A2A2;stroke-width:0.5;\" width=\"216.1572\" x=\"603\" y=\"388.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"43.4375\" x=\"647.1294\" y=\"413.1484\">Load</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"5.5703\" x=\"690.5669\" y=\"413.1484\"> </text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"78.8906\" x=\"696.1372\" y=\"413.1484\">Balancer</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"12\" lengthAdjust=\"spacing\" textLength=\"43.8398\" x=\"642.1079\" y=\"428.0605\">[Elastic</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"12\" lengthAdjust=\"spacing\" textLength=\"3.8145\" x=\"685.9478\" y=\"428.0605\"> </text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"12\" lengthAdjust=\"spacing\" textLength=\"28.998\" x=\"689.7622\" y=\"428.0605\">Load</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"12\" lengthAdjust=\"spacing\" textLength=\"3.8145\" x=\"718.7603\" y=\"428.0605\"> </text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"12\" lengthAdjust=\"spacing\" textLength=\"57.4746\" x=\"722.5747\" y=\"428.0605\">Balancer]</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"708.8535\" y=\"443.8857\"> </text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"96.4414\" x=\"623.4521\" y=\"460.1826\">Automatically</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"719.8936\" y=\"460.1826\"> </text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"74.3613\" x=\"724.3438\" y=\"460.1826\">distributes</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"64.3125\" x=\"613\" y=\"476.4795\">incoming</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"677.3125\" y=\"476.4795\"> </text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"77.2256\" x=\"681.7627\" y=\"476.4795\">application</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"758.9883\" y=\"476.4795\"> </text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"45.7188\" x=\"763.4385\" y=\"476.4795\">traffic.</text></g><!--entity Default.AmazonWebServices.useast1.AutoscalingGroup.AmazonEC2UbuntuServer.WebApplication_1--><g id=\"elem_Default.AmazonWebServices.useast1.AutoscalingGroup.AmazonEC2UbuntuServer.WebApplication_1\"><rect fill=\"#438DD5\" height=\"52.5938\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#3C7FC0;stroke-width:0.5;\" width=\"167.5781\" x=\"639\" y=\"632.2969\"/><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"39.9531\" x=\"649\" y=\"657.1484\">Web</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"5.5703\" x=\"688.9531\" y=\"657.1484\"> </text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"102.0547\" x=\"694.5234\" y=\"657.1484\">Application</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"30.0293\" x=\"655.5586\" y=\"672.0605\">[Java</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"3.8145\" x=\"685.5879\" y=\"672.0605\"> </text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"22.5762\" x=\"689.4023\" y=\"672.0605\">and</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"3.8145\" x=\"711.9785\" y=\"672.0605\"> </text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"38.7246\" x=\"715.793\" y=\"672.0605\">Spring</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"3.8145\" x=\"754.5176\" y=\"672.0605\"> </text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"31.6875\" x=\"758.332\" y=\"672.0605\">boot]</text></g><!--entity Default.AmazonWebServices.useast1.AmazonRDS.MySQL.DatabaseSchema_1--><g id=\"elem_Default.AmazonWebServices.useast1.AmazonRDS.MySQL.DatabaseSchema_1\"><path d=\"M849.5,226.2969 C849.5,216.2969 940.2188,216.2969 940.2188,216.2969 C940.2188,216.2969 1030.9375,216.2969 1030.9375,226.2969 L1030.9375,253.9219 C1030.9375,263.9219 940.2188,263.9219 940.2188,263.9219 C940.2188,263.9219 849.5,263.9219 849.5,253.9219 L849.5,226.2969 \" fill=\"#438DD5\" style=\"stroke:#3C7FC0;stroke-width:0.5;\"/><path d=\"M849.5,226.2969 C849.5,236.2969 940.2188,236.2969 940.2188,236.2969 C940.2188,236.2969 1030.9375,236.2969 1030.9375,226.2969 \" fill=\"none\" style=\"stroke:#3C7FC0;stroke-width:0.5;\"/><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"85.1484\" x=\"859.5\" y=\"255.1484\">Database</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"5.5703\" x=\"944.6484\" y=\"255.1484\"> </text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"70.7188\" x=\"950.2188\" y=\"255.1484\">Schema</text></g><!--entity Default.AmazonWebServices.apsoutheast1.DNSRouter--><g id=\"elem_Default.AmazonWebServices.apsoutheast1.DNSRouter\"><rect fill=\"#FFFFFF\" height=\"117.7813\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#A2A2A2;stroke-width:0.5;\" width=\"202.5947\" x=\"46.5\" y=\"181.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"38.1953\" x=\"95.3677\" y=\"206.1484\">DNS</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"5.5703\" x=\"133.563\" y=\"206.1484\"> </text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"61.0938\" x=\"139.1333\" y=\"206.1484\">Router</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"12\" lengthAdjust=\"spacing\" textLength=\"40.0547\" x=\"115.8872\" y=\"221.0605\">[Route</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"12\" lengthAdjust=\"spacing\" textLength=\"3.8145\" x=\"155.9419\" y=\"221.0605\"> </text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"12\" lengthAdjust=\"spacing\" textLength=\"19.9512\" x=\"159.7563\" y=\"221.0605\">53]</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"145.5723\" y=\"236.8857\"> </text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"48.5625\" x=\"56.5\" y=\"253.1826\">Routes</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"105.0625\" y=\"253.1826\"> </text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"64.3125\" x=\"109.5127\" y=\"253.1826\">incoming</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"173.8252\" y=\"253.1826\"> </text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"60.8193\" x=\"178.2754\" y=\"253.1826\">requests</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"42.2598\" x=\"126.6675\" y=\"269.4795\">based</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"35.1982\" x=\"77.4556\" y=\"285.7764\">upon</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"112.6538\" y=\"285.7764\"> </text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"52.4316\" x=\"117.104\" y=\"285.7764\">domain</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"169.5356\" y=\"285.7764\"> </text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"44.1533\" x=\"173.9858\" y=\"285.7764\">name.</text></g><!--entity Default.AmazonWebServices.apsoutheast1.LoadBalancer--><g id=\"elem_Default.AmazonWebServices.apsoutheast1.LoadBalancer\"><rect fill=\"#FFFFFF\" height=\"101.4844\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#A2A2A2;stroke-width:0.5;\" width=\"216.1572\" x=\"59\" y=\"388.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"43.4375\" x=\"103.1294\" y=\"413.1484\">Load</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"5.5703\" x=\"146.5669\" y=\"413.1484\"> </text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"78.8906\" x=\"152.1372\" y=\"413.1484\">Balancer</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"12\" lengthAdjust=\"spacing\" textLength=\"43.8398\" x=\"98.1079\" y=\"428.0605\">[Elastic</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"12\" lengthAdjust=\"spacing\" textLength=\"3.8145\" x=\"141.9478\" y=\"428.0605\"> </text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"12\" lengthAdjust=\"spacing\" textLength=\"28.998\" x=\"145.7622\" y=\"428.0605\">Load</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"12\" lengthAdjust=\"spacing\" textLength=\"3.8145\" x=\"174.7603\" y=\"428.0605\"> </text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"12\" lengthAdjust=\"spacing\" textLength=\"57.4746\" x=\"178.5747\" y=\"428.0605\">Balancer]</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"164.8535\" y=\"443.8857\"> </text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"96.4414\" x=\"79.4521\" y=\"460.1826\">Automatically</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"175.8936\" y=\"460.1826\"> </text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"74.3613\" x=\"180.3438\" y=\"460.1826\">distributes</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"64.3125\" x=\"69\" y=\"476.4795\">incoming</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"133.3125\" y=\"476.4795\"> </text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"77.2256\" x=\"137.7627\" y=\"476.4795\">application</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"214.9883\" y=\"476.4795\"> </text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"45.7188\" x=\"219.4385\" y=\"476.4795\">traffic.</text></g><!--entity Default.AmazonWebServices.apsoutheast1.AmazonRDS.MySQL.DatabaseSchema_1--><g id=\"elem_Default.AmazonWebServices.apsoutheast1.AmazonRDS.MySQL.DatabaseSchema_1\"><path d=\"M305.5,226.2969 C305.5,216.2969 396.2188,216.2969 396.2188,216.2969 C396.2188,216.2969 486.9375,216.2969 486.9375,226.2969 L486.9375,253.9219 C486.9375,263.9219 396.2188,263.9219 396.2188,263.9219 C396.2188,263.9219 305.5,263.9219 305.5,253.9219 L305.5,226.2969 \" fill=\"#438DD5\" style=\"stroke:#3C7FC0;stroke-width:0.5;\"/><path d=\"M305.5,226.2969 C305.5,236.2969 396.2188,236.2969 396.2188,236.2969 C396.2188,236.2969 486.9375,236.2969 486.9375,226.2969 \" fill=\"none\" style=\"stroke:#3C7FC0;stroke-width:0.5;\"/><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"85.1484\" x=\"315.5\" y=\"255.1484\">Database</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"5.5703\" x=\"400.6484\" y=\"255.1484\"> </text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"70.7188\" x=\"406.2188\" y=\"255.1484\">Schema</text></g><!--entity Default.AmazonWebServices.apsoutheast1.AutoscalingGroup.AmazonEC2UbuntuServer.WebApplication_1--><g id=\"elem_Default.AmazonWebServices.apsoutheast1.AutoscalingGroup.AmazonEC2UbuntuServer.WebApplication_1\"><rect fill=\"#438DD5\" height=\"52.5938\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#3C7FC0;stroke-width:0.5;\" width=\"167.5781\" x=\"95\" y=\"632.2969\"/><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"39.9531\" x=\"105\" y=\"657.1484\">Web</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"5.5703\" x=\"144.9531\" y=\"657.1484\"> </text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"102.0547\" x=\"150.5234\" y=\"657.1484\">Application</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"30.0293\" x=\"111.5586\" y=\"672.0605\">[Java</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"3.8145\" x=\"141.5879\" y=\"672.0605\"> </text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"22.5762\" x=\"145.4023\" y=\"672.0605\">and</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"3.8145\" x=\"167.9785\" y=\"672.0605\"> </text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"38.7246\" x=\"171.793\" y=\"672.0605\">Spring</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"3.8145\" x=\"210.5176\" y=\"672.0605\"> </text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"31.6875\" x=\"214.332\" y=\"672.0605\">boot]</text></g><!--link Default.AmazonWebServices.apsoutheast1.DNSRouter to Default.AmazonWebServices.apsoutheast1.LoadBalancer--><g id=\"link_Default.AmazonWebServices.apsoutheast1.DNSRouter_Default.AmazonWebServices.apsoutheast1.LoadBalancer\"><path d=\"M153.62,299.4569 C156.35,327.6369 158.8223,353.1638 161.4223,380.1338 \" fill=\"none\" id=\"Default.AmazonWebServices.apsoutheast1.DNSRouter-to-Default.AmazonWebServices.apsoutheast1.LoadBalancer\" style=\"stroke:#666666;stroke-width:1;\"/><polygon fill=\"#666666\" points=\"162.19,388.0969,164.4085,379.8459,158.4362,380.4217,162.19,388.0969\" style=\"stroke:#666666;stroke-width:1;\"/><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"57.2754\" x=\"161\" y=\"341.4355\">Fowards</text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"218.2754\" y=\"341.4355\"> </text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"59.3496\" x=\"222.4531\" y=\"341.4355\">requests</text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"281.8027\" y=\"341.4355\"> </text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"13.9805\" x=\"285.9805\" y=\"341.4355\">to</text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"40.2832\" x=\"210.3389\" y=\"355.4043\">[HTTP]</text></g><!--link Default.AmazonWebServices.apsoutheast1.LoadBalancer to Default.AmazonWebServices.apsoutheast1.AutoscalingGroup.AmazonEC2UbuntuServer.WebApplication_1--><g id=\"link_Default.AmazonWebServices.apsoutheast1.LoadBalancer_Default.AmazonWebServices.apsoutheast1.AutoscalingGroup.AmazonEC2UbuntuServer.WebApplication_1\"><path d=\"M169.74,489.5369 C172.18,533.8969 175.2213,589.0789 177.1413,624.0389 \" fill=\"none\" id=\"Default.AmazonWebServices.apsoutheast1.LoadBalancer-to-Default.AmazonWebServices.apsoutheast1.AutoscalingGroup.AmazonEC2UbuntuServer.WebApplication_1\" style=\"stroke:#666666;stroke-width:1;\"/><polygon fill=\"#666666\" points=\"177.58,632.0269,180.1368,623.8744,174.1458,624.2034,177.58,632.0269\" style=\"stroke:#666666;stroke-width:1;\"/><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"63.1934\" x=\"173\" y=\"531.4355\">Forwards</text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"236.1934\" y=\"531.4355\"> </text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"59.3496\" x=\"240.3711\" y=\"531.4355\">requests</text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"299.7207\" y=\"531.4355\"> </text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"13.9805\" x=\"303.8984\" y=\"531.4355\">to</text></g><!--link Default.AmazonWebServices.useast1.DNSRouter to Default.AmazonWebServices.useast1.LoadBalancer--><g id=\"link_Default.AmazonWebServices.useast1.DNSRouter_Default.AmazonWebServices.useast1.LoadBalancer\"><path d=\"M697.62,299.4569 C700.35,327.6369 702.8223,353.1638 705.4223,380.1338 \" fill=\"none\" id=\"Default.AmazonWebServices.useast1.DNSRouter-to-Default.AmazonWebServices.useast1.LoadBalancer\" style=\"stroke:#666666;stroke-width:1;\"/><polygon fill=\"#666666\" points=\"706.19,388.0969,708.4085,379.8459,702.4362,380.4217,706.19,388.0969\" style=\"stroke:#666666;stroke-width:1;\"/><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"57.2754\" x=\"704\" y=\"341.4355\">Fowards</text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"761.2754\" y=\"341.4355\"> </text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"59.3496\" x=\"765.4531\" y=\"341.4355\">requests</text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"824.8027\" y=\"341.4355\"> </text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"13.9805\" x=\"828.9805\" y=\"341.4355\">to</text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"40.2832\" x=\"753.3389\" y=\"355.4043\">[HTTP]</text></g><!--link Default.AmazonWebServices.useast1.LoadBalancer to Default.AmazonWebServices.useast1.AutoscalingGroup.AmazonEC2UbuntuServer.WebApplication_1--><g id=\"link_Default.AmazonWebServices.useast1.LoadBalancer_Default.AmazonWebServices.useast1.AutoscalingGroup.AmazonEC2UbuntuServer.WebApplication_1\"><path d=\"M713.74,489.5369 C716.18,533.8969 719.2213,589.0789 721.1413,624.0389 \" fill=\"none\" id=\"Default.AmazonWebServices.useast1.LoadBalancer-to-Default.AmazonWebServices.useast1.AutoscalingGroup.AmazonEC2UbuntuServer.WebApplication_1\" style=\"stroke:#666666;stroke-width:1;\"/><polygon fill=\"#666666\" points=\"721.58,632.0269,724.1368,623.8744,718.1458,624.2034,721.58,632.0269\" style=\"stroke:#666666;stroke-width:1;\"/><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"63.1934\" x=\"716\" y=\"531.4355\">Forwards</text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"779.1934\" y=\"531.4355\"> </text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"59.3496\" x=\"783.3711\" y=\"531.4355\">requests</text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"842.7207\" y=\"531.4355\"> </text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"13.9805\" x=\"846.8984\" y=\"531.4355\">to</text></g><rect fill=\"none\" height=\"16.2969\" style=\"stroke:none;stroke-width:1;\" width=\"96.291\" x=\"997.709\" y=\"797.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"57.9209\" x=\"997.709\" y=\"810.292\">Legend</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"1060.5039\" y=\"810.292\"> </text><rect fill=\"#438DD5\" height=\"16.2969\" style=\"stroke:none;stroke-width:1;\" width=\"96.291\" x=\"997.709\" y=\"813.5938\"/><text fill=\"#3C7FC0\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"7.7041\" x=\"1002.1592\" y=\"826.5889\">▯</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"1009.8633\" y=\"826.5889\"> </text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"66.3359\" x=\"1018.7637\" y=\"826.5889\">container</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"1089.5498\" y=\"826.5889\"> </text><rect fill=\"#FFFFFF\" height=\"16.2969\" style=\"stroke:none;stroke-width:1;\" width=\"96.291\" x=\"997.709\" y=\"829.8906\"/><text fill=\"#A2A2A2\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"7.7041\" x=\"1002.1592\" y=\"842.8857\">▯</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"1009.8633\" y=\"842.8857\"> </text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"34.9385\" x=\"1018.7637\" y=\"842.8857\">node</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"1058.1523\" y=\"842.8857\"> </text><line style=\"stroke:none;stroke-width:1;\" x1=\"997.709\" x2=\"1094\" y1=\"797.2969\" y2=\"797.2969\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"997.709\" x2=\"1094\" y1=\"813.5938\" y2=\"813.5938\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"997.709\" x2=\"1094\" y1=\"829.8906\" y2=\"829.8906\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"997.709\" x2=\"1094\" y1=\"846.1875\" y2=\"846.1875\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"997.709\" x2=\"997.709\" y1=\"797.2969\" y2=\"846.1875\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"1094\" x2=\"1094\" y1=\"797.2969\" y2=\"846.1875\"/><!--SRC=[rLRRRjD047ttLmmH3wtK61NA6wqKuhGL2W7YeZv6OtlIMDYxPdUs413_pjfEQeUceJ7D1Scovs9dpbpEPZGnQCfG8Ki5GWfoEEQ4e9FY3odWcWBmITt68MdmA4laD2N1ZiCo0vOGI6QPGXGh2ZcMmd6UnI9CJ4JmfdloedjozgTXr9M2wJilTs0iIDrtLP7F7ATIHWCPqO57OpG9koLaYtWE-0XQIz9e7S5pdcPqsigbY7IeIf7nHfTI4eilLZg4dmx0eyEvHXDgFhPXZMxdOljutM0DmhaTmrA7Q7_dva99a-LfLoOeRElZU0eairTxtPUV0oFOv1-GgjfY7T26qWUbimbGWBlHUJAGhlsqasL9768-rwEyg_aKrMm5AWeduhJr3cyHK4JWPoglUI0b_nN_3Fqlnwaz6XIzy0mzlwghLRRKy7biz_tK_zIt28hdFpRH2zOFxNh86A0cFvnGYaM_vYOeRRL-RQitti0VIiF5p5iPIgKgJw73wrSrF8L9Wpq0PPgFagAlXZHho3E9m6Islv5CRQ50O4hk2lphu-rBZDvYWY8i8ESgpFKATI-nBySXt7FFKiWPbbgAM98bK_lVe5d5mM9MMD48ME5u78SFPrAK__79OAPj3IVpinYpzfs-sGEv7dWdj5mEO7lSN1L_lmYwWFH_OUa2wFsaQlDftVaIinBENcqo3P3kPfsnDtiDAMd0n6OqE9VVK4MwuYFBMbwNLrSV7m2_1iZ5a1jlqxbKgt9gbC-I_MJjvM13fLuURPDhVRC2E_xbX-jHltVH6tW7h0mT_WO0]--></g></svg>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.SVG object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from IPython.display import SVG, display, HTML\n",
     "\n",
     "# Get SVG content for all views\n",
-    "svgs = w.to_svg_string()\n",
+    "svgs = w.to_svg()\n",
     "\n",
     "for view_key, svg_content in svgs.items():\n",
     "    display(HTML(f\"<h3>{view_key}</h3>\"))\n",
@@ -683,631 +199,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/json": {
-       "configuration": {
-        "scope": "SoftwareSystem"
-       },
-       "description": "An example AWS deployment architecture",
-       "documentation": {},
-       "id": 1,
-       "model": {
-        "deploymentNodes": [
-         {
-          "children": [
-           {
-            "children": [
-             {
-              "children": [
-               {
-                "children": [],
-                "containerInstances": [
-                 {
-                  "containerId": "3",
-                  "deploymentGroups": [
-                   "region-1"
-                  ],
-                  "environment": "Live",
-                  "id": "18",
-                  "relationships": [
-                   {
-                    "description": "Reads from and writes to",
-                    "destinationId": "21",
-                    "id": "33",
-                    "linkedRelationshipId": "5",
-                    "sourceId": "18",
-                    "tags": "Relationship",
-                    "technology": ""
-                   }
-                  ],
-                  "tags": "Container Instance"
-                 }
-                ],
-                "description": "",
-                "environment": "Live",
-                "id": "16",
-                "infrastructureNodes": [],
-                "instances": "1",
-                "name": "Amazon EC2 - Ubuntu Server",
-                "softwareSystemInstances": [],
-                "tags": "Deployment Node,Element,Amazon Web Services - EC2 Instance",
-                "technology": ""
-               }
-              ],
-              "containerInstances": [],
-              "description": "",
-              "environment": "Live",
-              "id": "15",
-              "infrastructureNodes": [],
-              "instances": "1",
-              "name": "Autoscaling Group",
-              "softwareSystemInstances": [],
-              "tags": "Deployment Node,Element,Amazon Web Services - Autoscaling Group",
-              "technology": ""
-             },
-             {
-              "children": [
-               {
-                "children": [],
-                "containerInstances": [
-                 {
-                  "containerId": "4",
-                  "deploymentGroups": [
-                   "region-1"
-                  ],
-                  "environment": "Live",
-                  "id": "21",
-                  "tags": "Container Instance"
-                 }
-                ],
-                "description": "",
-                "environment": "Live",
-                "id": "20",
-                "infrastructureNodes": [],
-                "instances": "1",
-                "name": "MySQL",
-                "softwareSystemInstances": [],
-                "tags": "Deployment Node,Element,Amazon Web Services - RDS MySQL instance",
-                "technology": ""
-               }
-              ],
-              "containerInstances": [],
-              "description": "",
-              "environment": "Live",
-              "id": "19",
-              "infrastructureNodes": [],
-              "instances": "1",
-              "name": "Amazon RDS",
-              "softwareSystemInstances": [],
-              "tags": "Deployment Node,Element,Amazon Web Services - RDS Instance",
-              "technology": ""
-             }
-            ],
-            "containerInstances": [],
-            "description": "",
-            "environment": "Live",
-            "id": "11",
-            "infrastructureNodes": [
-             {
-              "description": "Routes incoming requests based upon domain name.",
-              "environment": "Live",
-              "id": "12",
-              "name": "DNS Router",
-              "properties": {},
-              "relationships": [
-               {
-                "description": "Fowards requests to",
-                "destinationId": "13",
-                "id": "14",
-                "sourceId": "12",
-                "tags": "Relationship",
-                "technology": "HTTP"
-               }
-              ],
-              "tags": "Element,Amazon Web Services - Route 53,Infrastructure Node",
-              "technology": "Route 53"
-             },
-             {
-              "description": "Automatically distributes incoming application traffic.",
-              "environment": "Live",
-              "id": "13",
-              "name": "Load Balancer",
-              "properties": {},
-              "relationships": [
-               {
-                "description": "Forwards requests to",
-                "destinationId": "18",
-                "id": "17",
-                "sourceId": "13",
-                "tags": "Relationship",
-                "technology": ""
-               }
-              ],
-              "tags": "Element,Amazon Web Services - Elastic Load Balancer,Infrastructure Node",
-              "technology": "Elastic Load Balancer"
-             }
-            ],
-            "instances": "1",
-            "name": "ap-southeast-1",
-            "softwareSystemInstances": [],
-            "tags": "Deployment Node,Element,Amazon Web Services - Region",
-            "technology": ""
-           },
-           {
-            "children": [
-             {
-              "children": [
-               {
-                "children": [],
-                "containerInstances": [
-                 {
-                  "containerId": "3",
-                  "deploymentGroups": [
-                   "region-2"
-                  ],
-                  "environment": "Live",
-                  "id": "29",
-                  "relationships": [
-                   {
-                    "description": "Reads from and writes to",
-                    "destinationId": "32",
-                    "id": "34",
-                    "linkedRelationshipId": "5",
-                    "sourceId": "29",
-                    "tags": "Relationship",
-                    "technology": ""
-                   }
-                  ],
-                  "tags": "Container Instance"
-                 }
-                ],
-                "description": "",
-                "environment": "Live",
-                "id": "27",
-                "infrastructureNodes": [],
-                "instances": "1",
-                "name": "Amazon EC2 - Ubuntu Server",
-                "softwareSystemInstances": [],
-                "tags": "Deployment Node,Element,Amazon Web Services - EC2 Instance",
-                "technology": ""
-               }
-              ],
-              "containerInstances": [],
-              "description": "",
-              "environment": "Live",
-              "id": "26",
-              "infrastructureNodes": [],
-              "instances": "1",
-              "name": "Autoscaling Group",
-              "softwareSystemInstances": [],
-              "tags": "Deployment Node,Element,Amazon Web Services - Autoscaling Group",
-              "technology": ""
-             },
-             {
-              "children": [
-               {
-                "children": [],
-                "containerInstances": [
-                 {
-                  "containerId": "4",
-                  "deploymentGroups": [
-                   "region-2"
-                  ],
-                  "environment": "Live",
-                  "id": "32",
-                  "tags": "Container Instance"
-                 }
-                ],
-                "description": "",
-                "environment": "Live",
-                "id": "31",
-                "infrastructureNodes": [],
-                "instances": "1",
-                "name": "MySQL",
-                "softwareSystemInstances": [],
-                "tags": "Deployment Node,Element,Amazon Web Services - RDS MySQL instance",
-                "technology": ""
-               }
-              ],
-              "containerInstances": [],
-              "description": "",
-              "environment": "Live",
-              "id": "30",
-              "infrastructureNodes": [],
-              "instances": "1",
-              "name": "Amazon RDS",
-              "softwareSystemInstances": [],
-              "tags": "Deployment Node,Element,Amazon Web Services - RDS Instance",
-              "technology": ""
-             }
-            ],
-            "containerInstances": [],
-            "description": "",
-            "environment": "Live",
-            "id": "22",
-            "infrastructureNodes": [
-             {
-              "description": "Routes incoming requests based upon domain name.",
-              "environment": "Live",
-              "id": "23",
-              "name": "DNS Router",
-              "properties": {},
-              "relationships": [
-               {
-                "description": "Fowards requests to",
-                "destinationId": "24",
-                "id": "25",
-                "sourceId": "23",
-                "tags": "Relationship",
-                "technology": "HTTP"
-               }
-              ],
-              "tags": "Element,Amazon Web Services - Route 53,Infrastructure Node",
-              "technology": "Route 53"
-             },
-             {
-              "description": "Automatically distributes incoming application traffic.",
-              "environment": "Live",
-              "id": "24",
-              "name": "Load Balancer",
-              "properties": {},
-              "relationships": [
-               {
-                "description": "Forwards requests to",
-                "destinationId": "29",
-                "id": "28",
-                "sourceId": "24",
-                "tags": "Relationship",
-                "technology": ""
-               }
-              ],
-              "tags": "Element,Amazon Web Services - Elastic Load Balancer,Infrastructure Node",
-              "technology": "Elastic Load Balancer"
-             }
-            ],
-            "instances": "1",
-            "name": "us-east-1",
-            "softwareSystemInstances": [],
-            "tags": "Deployment Node,Element,Amazon Web Services - Region",
-            "technology": ""
-           }
-          ],
-          "containerInstances": [],
-          "description": "",
-          "environment": "Live",
-          "id": "10",
-          "infrastructureNodes": [],
-          "instances": "1",
-          "name": "Amazon Web Services",
-          "softwareSystemInstances": [],
-          "tags": "Deployment Node,Element,Amazon Web Services - Cloud",
-          "technology": ""
-         }
-        ],
-        "people": [
-         {
-          "description": "An ordinary user.",
-          "id": "1",
-          "location": "Unspecified",
-          "name": "User",
-          "properties": {},
-          "relationships": [
-           {
-            "description": "Uses",
-            "destinationId": "2",
-            "id": "9",
-            "sourceId": "1",
-            "tags": "Relationship",
-            "technology": "browser"
-           }
-          ],
-          "tags": "Element,buildzr-styleelements-0b2892fe79dc4b01832bec8cf485fd49,Person"
-         }
-        ],
-        "properties": {
-         "structurizr.groupSeparator": "/"
-        },
-        "softwareSystems": [
-         {
-          "containers": [
-           {
-            "components": [
-             {
-              "description": "",
-              "id": "6",
-              "name": "API Layer",
-              "properties": {},
-              "relationships": [
-               {
-                "description": "Runs queries/transactions on",
-                "destinationId": "7",
-                "id": "8",
-                "sourceId": "6",
-                "tags": "Relationship",
-                "technology": ""
-               }
-              ],
-              "tags": "Element,Component",
-              "technology": ""
-             },
-             {
-              "description": "",
-              "id": "7",
-              "name": "Database Layer",
-              "properties": {},
-              "relationships": [],
-              "tags": "Element,Component",
-              "technology": ""
-             }
-            ],
-            "description": "",
-            "id": "3",
-            "name": "Web Application",
-            "properties": {},
-            "relationships": [
-             {
-              "description": "Reads from and writes to",
-              "destinationId": "4",
-              "id": "5",
-              "sourceId": "3",
-              "tags": "Relationship",
-              "technology": ""
-             }
-            ],
-            "tags": "Element,buildzr-styleelements-528158d949d34a899dcac10132f2aa39,Container",
-            "technology": "Java and Spring boot"
-           },
-           {
-            "components": [],
-            "description": "",
-            "id": "4",
-            "name": "Database Schema",
-            "properties": {},
-            "relationships": [],
-            "tags": "Element,buildzr-styleelements-a10d9e75db0c40a292b1d7ca315ccce3,Container",
-            "technology": ""
-           }
-          ],
-          "description": "",
-          "documentation": {},
-          "id": "2",
-          "location": "Unspecified",
-          "name": "X",
-          "properties": {},
-          "relationships": [],
-          "tags": "Element,Software System"
-         }
-        ]
-       },
-       "name": "Amazon Web Services Example",
-       "views": {
-        "configuration": {
-         "branding": {},
-         "styles": {
-          "elements": [
-           {
-            "background": "#ffffff",
-            "tag": "Element"
-           },
-           {
-            "background": "#ffffff",
-            "tag": "Container"
-           },
-           {
-            "background": "#ffffff",
-            "tag": "buildzr-styleelements-528158d949d34a899dcac10132f2aa39"
-           },
-           {
-            "shape": "Person",
-            "tag": "buildzr-styleelements-0b2892fe79dc4b01832bec8cf485fd49"
-           },
-           {
-            "shape": "Cylinder",
-            "tag": "buildzr-styleelements-a10d9e75db0c40a292b1d7ca315ccce3"
-           }
-          ]
-         },
-         "terminology": {}
-        },
-        "deploymentViews": [
-         {
-          "automaticLayout": {
-           "edgeSeparation": 0,
-           "implementation": "Graphviz",
-           "nodeSeparation": 300,
-           "rankDirection": "LeftRight",
-           "rankSeparation": 300,
-           "vertices": false
-          },
-          "description": "Deployment view of the web application on AWS",
-          "elements": [
-           {
-            "id": "10",
-            "x": 0,
-            "y": 0
-           },
-           {
-            "id": "11",
-            "x": 0,
-            "y": 0
-           },
-           {
-            "id": "12",
-            "x": 0,
-            "y": 0
-           },
-           {
-            "id": "13",
-            "x": 0,
-            "y": 0
-           },
-           {
-            "id": "15",
-            "x": 0,
-            "y": 0
-           },
-           {
-            "id": "16",
-            "x": 0,
-            "y": 0
-           },
-           {
-            "id": "18",
-            "x": 0,
-            "y": 0
-           },
-           {
-            "id": "19",
-            "x": 0,
-            "y": 0
-           },
-           {
-            "id": "20",
-            "x": 0,
-            "y": 0
-           },
-           {
-            "id": "21",
-            "x": 0,
-            "y": 0
-           },
-           {
-            "id": "22",
-            "x": 0,
-            "y": 0
-           },
-           {
-            "id": "23",
-            "x": 0,
-            "y": 0
-           },
-           {
-            "id": "24",
-            "x": 0,
-            "y": 0
-           },
-           {
-            "id": "26",
-            "x": 0,
-            "y": 0
-           },
-           {
-            "id": "27",
-            "x": 0,
-            "y": 0
-           },
-           {
-            "id": "29",
-            "x": 0,
-            "y": 0
-           },
-           {
-            "id": "30",
-            "x": 0,
-            "y": 0
-           },
-           {
-            "id": "31",
-            "x": 0,
-            "y": 0
-           },
-           {
-            "id": "32",
-            "x": 0,
-            "y": 0
-           }
-          ],
-          "environment": "Live",
-          "key": "aws-deployment-view",
-          "relationships": [
-           {
-            "id": "14"
-           },
-           {
-            "id": "17"
-           },
-           {
-            "id": "33"
-           },
-           {
-            "id": "25"
-           },
-           {
-            "id": "28"
-           },
-           {
-            "id": "34"
-           }
-          ],
-          "softwareSystemId": "2",
-          "title": "Amazon Web Services Deployment"
-         }
-        ],
-        "systemContextViews": [
-         {
-          "automaticLayout": {
-           "applied": false,
-           "edgeSeparation": 0,
-           "implementation": "Graphviz",
-           "nodeSeparation": 300,
-           "rankDirection": "TopBottom",
-           "rankSeparation": 300,
-           "vertices": false
-          },
-          "description": "System context of X",
-          "elements": [
-           {
-            "id": "1",
-            "x": 0,
-            "y": 0
-           },
-           {
-            "id": "2",
-            "x": 0,
-            "y": 0
-           }
-          ],
-          "enterpriseBoundaryVisible": true,
-          "key": "x_context_00",
-          "order": 1,
-          "relationships": [
-           {
-            "id": "9"
-           }
-          ],
-          "softwareSystemId": "2"
-         }
-        ]
-       }
-      },
-      "text/html": [
-       "<div style=\"margin-bottom: 2em;\">\n",
-       "<h3 style=\"font-family: sans-serif; color: #333;\">x_context_00</h3>\n",
-       "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" contentStyleType=\"text/css\" height=\"390px\" preserveAspectRatio=\"none\" style=\"width:179px;height:390px;background:#FFFFFF;\" version=\"1.1\" viewBox=\"0 0 179 390\" width=\"179px\" zoomAndPan=\"magnify\"><title>X - System Context</title><defs/><g><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"151.3135\" x=\"10\" y=\"22.9951\">X - System Context</text><!--entity User--><g id=\"elem_User\"><rect fill=\"#08427B\" height=\"119.2188\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#073B6F;stroke-width:0.5;\" width=\"140.9277\" x=\"22.6929\" y=\"44.2969\"/><image height=\"48\" width=\"48\" x=\"69.1567\" xlink:href=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAACMElEQVR4Xu2YvUrFQBCFb+kj+Ai+gq3Y2PgA+gCCtZ2V2AhqaSNiqY1gYWMjaCvXykoEKy21sLCNfELgMscksz8mWfDAB3Kuye7sTmYnmcwtbU9KRozSECOVla3T6uTqvrqZPlcPT68/XNw+VtvH19XC+sGe/f9UxIhl8/Cy+vj8qrpEYIsbR1N7fSxihDK/urvMKoeKHbH3ikGMEJi8Z9WbtH92lxyEGCHErLwVqWfvG4IYXkiBXGIn7f29iOGBAe0kUkTVsmN4EcMD255bdgwvYnigFOYW54cdx4MYHlIqT5Niy6oYHuzgORRbUsXwYAfPoV4DeHl7t+MnK/Y8EMMDzVlu9foQ5y6jFAU7hhcxvOSsRLH5D2J4KbqVqMlxoK3tnEevPogRAiuXUpFiD69ZxIghZidSV75GjFiYkGc3KMEpOW8RIxXed0kNJsrOAO0ypTfnxGvEKA0xSkMMD3zfIedJFQ4hCPlUwrX1daQWbURseonRBhNue1D5rc53JkVQwN9c21Wt+D20JxLjN7hpztahSwTi3RExLDlbhhCxm55PkWLMkrvrDBW73rUTYtSQu/aGQ4h0snNzBdD1wPWptrZDDBjL6tfiebBzbA2AUjg2NT3QYkBbrR9KTS/9YoC9eAxqeu0UI/eH21yiu7VzLSqApnIqxn8Af6TiA3A/A9Bn5+lV0xcMMWDoJs6qrakTo4a6OwZxqLa97YkxC1HzMkMzNQRtE3cFUAJilMY3OGTNL0NDLqIAAAAASUVORK5CYII=\" y=\"54.2969\"/><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"41.2578\" x=\"72.5278\" y=\"117.1484\">User</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"90.9316\" y=\"133.917\">&#160;</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"18.4502\" x=\"32.6929\" y=\"150.2139\">An</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"51.1431\" y=\"150.2139\">&#160;</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"58.5908\" x=\"55.5933\" y=\"150.2139\">ordinary</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"114.1841\" y=\"150.2139\">&#160;</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"34.9863\" x=\"118.6343\" y=\"150.2139\">user.</text></g><!--entity X--><g id=\"elem_X\"><rect fill=\"#1168BD\" height=\"38.625\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#3C7FC0;stroke-width:0.5;\" width=\"32.3359\" x=\"77.1929\" y=\"252.2969\"/><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"12.3359\" x=\"87.1929\" y=\"277.1484\">X</text></g><!--link User to X--><g id=\"link_User_X\"><path d=\"M93.1929,163.3269 C93.1929,194.4969 93.1929,222.7369 93.1929,244.1669 \" fill=\"none\" id=\"User-to-X\" style=\"stroke:#666666;stroke-width:1;\"/><polygon fill=\"#666666\" points=\"93.1929,252.1669,96.1929,244.1669,90.1929,244.1669,93.1929,252.1669\" style=\"stroke:#666666;stroke-width:1;\"/><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"32.168\" x=\"106.9282\" y=\"205.4355\">Uses</text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"57.6387\" x=\"94.1929\" y=\"219.4043\">[browser]</text></g><rect fill=\"none\" height=\"16.2969\" style=\"stroke:none;stroke-width:1;\" width=\"94.3936\" x=\"44.2271\" y=\"314.9219\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"57.9209\" x=\"44.2271\" y=\"327.917\">Legend</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"107.022\" y=\"327.917\">&#160;</text><rect fill=\"#08427B\" height=\"16.2969\" style=\"stroke:none;stroke-width:1;\" width=\"94.3936\" x=\"44.2271\" y=\"331.2188\"/><text fill=\"#073B6F\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"7.7041\" x=\"48.6772\" y=\"344.2139\">&#9647;</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"56.3813\" y=\"344.2139\">&#160;</text><image height=\"12\" width=\"12\" x=\"60.8315\" xlink:href=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAApklEQVR4XmPgcKpmQMfRjcsb/CoWNqCLgzCGwH80gC6Pwjl17RG6+v9T1h47gFPD95+/0dX/33v2DootKBriW1Y2oGvQjesPxKkBhDuW7D8AUxzfunIiujwKRzWyO8ksdXIxjG+XPaNBNqgNuw3IzkAHIL+haNh67MZndEXooGXh3kVwDeiS2MCtx6/BtoA1/P7zF10eA5y69hihAYQNkyY24MMwdQBvKDvWFDAX9QAAAABJRU5ErkJggg==\" y=\"335.5156\"/><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"47.9883\" x=\"81.7319\" y=\"344.2139\">person</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"134.1704\" y=\"344.2139\">&#160;</text><rect fill=\"#1168BD\" height=\"16.2969\" style=\"stroke:none;stroke-width:1;\" width=\"94.3936\" x=\"44.2271\" y=\"347.5156\"/><text fill=\"#3C7FC0\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"7.7041\" x=\"48.6772\" y=\"360.5107\">&#9647;</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"56.3813\" y=\"360.5107\">&#160;</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"50.6133\" x=\"65.2817\" y=\"360.5107\">system</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"120.3452\" y=\"360.5107\">&#160;</text><line style=\"stroke:none;stroke-width:1;\" x1=\"44.2271\" x2=\"138.6206\" y1=\"314.9219\" y2=\"314.9219\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"44.2271\" x2=\"138.6206\" y1=\"331.2188\" y2=\"331.2188\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"44.2271\" x2=\"138.6206\" y1=\"347.5156\" y2=\"347.5156\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"44.2271\" x2=\"138.6206\" y1=\"363.8125\" y2=\"363.8125\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"44.2271\" x2=\"44.2271\" y1=\"314.9219\" y2=\"363.8125\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"138.6206\" x2=\"138.6206\" y1=\"314.9219\" y2=\"363.8125\"/><!--SRC=[TKvDQy9W3BxdLsGlExIWsyMZ5QIA7iOsBCFUfBP1Nwo9v4tP-k_NhZt8s4vvoFCPo33GhT32H9652SnRJPZZ5BCs65qn5JRwCW2J6vhWKSpaYfLNAiqB0pnuBkkc8fodi-TqjlZzE8mH2u1tqY0SVGJI2Rh-k0a-LXHAJToIKRJoN6YBJKSzzPmLfv2u7jMUBnsAOHWMvLr2VcV_HmqxgiV2VEWCFqegpvoueyhdkE8lRxPzsnzUrflrwoeoRIZ-1W00]--></g></svg>\n",
-       "</div>\n",
-       "<div style=\"margin-bottom: 2em;\">\n",
-       "<h3 style=\"font-family: sans-serif; color: #333;\">aws-deployment-view</h3>\n",
-       "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" contentStyleType=\"text/css\" height=\"873px\" preserveAspectRatio=\"none\" style=\"width:1125px;height:873px;background:#FFFFFF;\" version=\"1.1\" viewBox=\"0 0 1125 873\" width=\"1125px\" zoomAndPan=\"magnify\"><title>Amazon Web Services Deployment</title><defs/><g><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"274.1416\" x=\"418.4292\" y=\"22.9951\">Amazon Web Services Deployment</text><!--cluster Default.AmazonWebServices--><g id=\"cluster_Default.AmazonWebServices\"><rect fill=\"#FFFFFF\" height=\"729\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#A2A2A2;stroke-width:1;\" width=\"1112\" x=\"7\" y=\"44.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"198.6797\" x=\"463.6602\" y=\"61.1484\">Amazon Web Services</text></g><!--cluster Default.AmazonWebServices.useast1--><g id=\"cluster_Default.AmazonWebServices.useast1\"><rect fill=\"#FFFFFF\" height=\"660\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#A2A2A2;stroke-width:1;\" width=\"520\" x=\"575\" y=\"89.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"84.1484\" x=\"792.9258\" y=\"106.1484\">us-east-1</text></g><!--cluster Default.AmazonWebServices.useast1.AutoscalingGroup--><g id=\"cluster_Default.AmazonWebServices.useast1.AutoscalingGroup\"><rect fill=\"#FFFFFF\" height=\"175\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#A2A2A2;stroke-width:1;\" width=\"323\" x=\"599\" y=\"550.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"166.4609\" x=\"677.2695\" y=\"567.1484\">Autoscaling Group</text></g><!--cluster Default.AmazonWebServices.useast1.AutoscalingGroup.AmazonEC2UbuntuServer--><g id=\"cluster_Default.AmazonWebServices.useast1.AutoscalingGroup.AmazonEC2UbuntuServer\"><rect fill=\"#FFFFFF\" height=\"106\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#A2A2A2;stroke-width:1;\" width=\"275\" x=\"623\" y=\"595.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"259.9766\" x=\"630.5117\" y=\"612.1484\">Amazon EC2 - Ubuntu Server</text></g><!--cluster Default.AmazonWebServices.useast1.AmazonRDS--><g id=\"cluster_Default.AmazonWebServices.useast1.AmazonRDS\"><rect fill=\"#FFFFFF\" height=\"170\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#A2A2A2;stroke-width:1;\" width=\"262\" x=\"809\" y=\"134.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"114.2422\" x=\"882.8789\" y=\"151.1484\">Amazon RDS</text></g><!--cluster Default.AmazonWebServices.useast1.AmazonRDS.MySQL--><g id=\"cluster_Default.AmazonWebServices.useast1.AmazonRDS.MySQL\"><rect fill=\"#FFFFFF\" height=\"101\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#A2A2A2;stroke-width:1;\" width=\"214\" x=\"833\" y=\"179.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"61.6719\" x=\"909.1641\" y=\"196.1484\">MySQL</text></g><!--cluster Default.AmazonWebServices.apsoutheast1--><g id=\"cluster_Default.AmazonWebServices.apsoutheast1\"><rect fill=\"#FFFFFF\" height=\"660\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#A2A2A2;stroke-width:1;\" width=\"520\" x=\"31\" y=\"89.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"136.4297\" x=\"222.7852\" y=\"106.1484\">ap-southeast-1</text></g><!--cluster Default.AmazonWebServices.apsoutheast1.AmazonRDS--><g id=\"cluster_Default.AmazonWebServices.apsoutheast1.AmazonRDS\"><rect fill=\"#FFFFFF\" height=\"170\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#A2A2A2;stroke-width:1;\" width=\"262\" x=\"265\" y=\"134.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"114.2422\" x=\"338.8789\" y=\"151.1484\">Amazon RDS</text></g><!--cluster Default.AmazonWebServices.apsoutheast1.AmazonRDS.MySQL--><g id=\"cluster_Default.AmazonWebServices.apsoutheast1.AmazonRDS.MySQL\"><rect fill=\"#FFFFFF\" height=\"101\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#A2A2A2;stroke-width:1;\" width=\"214\" x=\"289\" y=\"179.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"61.6719\" x=\"365.1641\" y=\"196.1484\">MySQL</text></g><!--cluster Default.AmazonWebServices.apsoutheast1.AutoscalingGroup--><g id=\"cluster_Default.AmazonWebServices.apsoutheast1.AutoscalingGroup\"><rect fill=\"#FFFFFF\" height=\"175\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#A2A2A2;stroke-width:1;\" width=\"323\" x=\"55\" y=\"550.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"166.4609\" x=\"133.2695\" y=\"567.1484\">Autoscaling Group</text></g><!--cluster Default.AmazonWebServices.apsoutheast1.AutoscalingGroup.AmazonEC2UbuntuServer--><g id=\"cluster_Default.AmazonWebServices.apsoutheast1.AutoscalingGroup.AmazonEC2UbuntuServer\"><rect fill=\"#FFFFFF\" height=\"106\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#A2A2A2;stroke-width:1;\" width=\"275\" x=\"79\" y=\"595.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"259.9766\" x=\"86.5117\" y=\"612.1484\">Amazon EC2 - Ubuntu Server</text></g><!--entity Default.AmazonWebServices.useast1.DNSRouter--><g id=\"elem_Default.AmazonWebServices.useast1.DNSRouter\"><rect fill=\"#FFFFFF\" height=\"117.7813\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#A2A2A2;stroke-width:0.5;\" width=\"202.5947\" x=\"590.5\" y=\"181.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"38.1953\" x=\"639.3677\" y=\"206.1484\">DNS</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"5.5703\" x=\"677.563\" y=\"206.1484\">&#160;</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"61.0938\" x=\"683.1333\" y=\"206.1484\">Router</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"12\" lengthAdjust=\"spacing\" textLength=\"40.0547\" x=\"659.8872\" y=\"221.0605\">[Route</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"12\" lengthAdjust=\"spacing\" textLength=\"3.8145\" x=\"699.9419\" y=\"221.0605\">&#160;</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"12\" lengthAdjust=\"spacing\" textLength=\"19.9512\" x=\"703.7563\" y=\"221.0605\">53]</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"689.5723\" y=\"236.8857\">&#160;</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"48.5625\" x=\"600.5\" y=\"253.1826\">Routes</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"649.0625\" y=\"253.1826\">&#160;</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"64.3125\" x=\"653.5127\" y=\"253.1826\">incoming</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"717.8252\" y=\"253.1826\">&#160;</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"60.8193\" x=\"722.2754\" y=\"253.1826\">requests</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"42.2598\" x=\"670.6675\" y=\"269.4795\">based</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"35.1982\" x=\"621.4556\" y=\"285.7764\">upon</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"656.6538\" y=\"285.7764\">&#160;</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"52.4316\" x=\"661.104\" y=\"285.7764\">domain</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"713.5356\" y=\"285.7764\">&#160;</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"44.1533\" x=\"717.9858\" y=\"285.7764\">name.</text></g><!--entity Default.AmazonWebServices.useast1.LoadBalancer--><g id=\"elem_Default.AmazonWebServices.useast1.LoadBalancer\"><rect fill=\"#FFFFFF\" height=\"101.4844\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#A2A2A2;stroke-width:0.5;\" width=\"216.1572\" x=\"603\" y=\"388.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"43.4375\" x=\"647.1294\" y=\"413.1484\">Load</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"5.5703\" x=\"690.5669\" y=\"413.1484\">&#160;</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"78.8906\" x=\"696.1372\" y=\"413.1484\">Balancer</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"12\" lengthAdjust=\"spacing\" textLength=\"43.8398\" x=\"642.1079\" y=\"428.0605\">[Elastic</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"12\" lengthAdjust=\"spacing\" textLength=\"3.8145\" x=\"685.9478\" y=\"428.0605\">&#160;</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"12\" lengthAdjust=\"spacing\" textLength=\"28.998\" x=\"689.7622\" y=\"428.0605\">Load</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"12\" lengthAdjust=\"spacing\" textLength=\"3.8145\" x=\"718.7603\" y=\"428.0605\">&#160;</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"12\" lengthAdjust=\"spacing\" textLength=\"57.4746\" x=\"722.5747\" y=\"428.0605\">Balancer]</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"708.8535\" y=\"443.8857\">&#160;</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"96.4414\" x=\"623.4521\" y=\"460.1826\">Automatically</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"719.8936\" y=\"460.1826\">&#160;</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"74.3613\" x=\"724.3438\" y=\"460.1826\">distributes</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"64.3125\" x=\"613\" y=\"476.4795\">incoming</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"677.3125\" y=\"476.4795\">&#160;</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"77.2256\" x=\"681.7627\" y=\"476.4795\">application</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"758.9883\" y=\"476.4795\">&#160;</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"45.7188\" x=\"763.4385\" y=\"476.4795\">traffic.</text></g><!--entity Default.AmazonWebServices.useast1.AutoscalingGroup.AmazonEC2UbuntuServer.WebApplication_1--><g id=\"elem_Default.AmazonWebServices.useast1.AutoscalingGroup.AmazonEC2UbuntuServer.WebApplication_1\"><rect fill=\"#438DD5\" height=\"52.5938\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#3C7FC0;stroke-width:0.5;\" width=\"167.5781\" x=\"639\" y=\"632.2969\"/><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"39.9531\" x=\"649\" y=\"657.1484\">Web</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"5.5703\" x=\"688.9531\" y=\"657.1484\">&#160;</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"102.0547\" x=\"694.5234\" y=\"657.1484\">Application</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"30.0293\" x=\"655.5586\" y=\"672.0605\">[Java</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"3.8145\" x=\"685.5879\" y=\"672.0605\">&#160;</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"22.5762\" x=\"689.4023\" y=\"672.0605\">and</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"3.8145\" x=\"711.9785\" y=\"672.0605\">&#160;</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"38.7246\" x=\"715.793\" y=\"672.0605\">Spring</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"3.8145\" x=\"754.5176\" y=\"672.0605\">&#160;</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"31.6875\" x=\"758.332\" y=\"672.0605\">boot]</text></g><!--entity Default.AmazonWebServices.useast1.AmazonRDS.MySQL.DatabaseSchema_1--><g id=\"elem_Default.AmazonWebServices.useast1.AmazonRDS.MySQL.DatabaseSchema_1\"><path d=\"M849.5,226.2969 C849.5,216.2969 940.2188,216.2969 940.2188,216.2969 C940.2188,216.2969 1030.9375,216.2969 1030.9375,226.2969 L1030.9375,253.9219 C1030.9375,263.9219 940.2188,263.9219 940.2188,263.9219 C940.2188,263.9219 849.5,263.9219 849.5,253.9219 L849.5,226.2969 \" fill=\"#438DD5\" style=\"stroke:#3C7FC0;stroke-width:0.5;\"/><path d=\"M849.5,226.2969 C849.5,236.2969 940.2188,236.2969 940.2188,236.2969 C940.2188,236.2969 1030.9375,236.2969 1030.9375,226.2969 \" fill=\"none\" style=\"stroke:#3C7FC0;stroke-width:0.5;\"/><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"85.1484\" x=\"859.5\" y=\"255.1484\">Database</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"5.5703\" x=\"944.6484\" y=\"255.1484\">&#160;</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"70.7188\" x=\"950.2188\" y=\"255.1484\">Schema</text></g><!--entity Default.AmazonWebServices.apsoutheast1.DNSRouter--><g id=\"elem_Default.AmazonWebServices.apsoutheast1.DNSRouter\"><rect fill=\"#FFFFFF\" height=\"117.7813\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#A2A2A2;stroke-width:0.5;\" width=\"202.5947\" x=\"46.5\" y=\"181.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"38.1953\" x=\"95.3677\" y=\"206.1484\">DNS</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"5.5703\" x=\"133.563\" y=\"206.1484\">&#160;</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"61.0938\" x=\"139.1333\" y=\"206.1484\">Router</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"12\" lengthAdjust=\"spacing\" textLength=\"40.0547\" x=\"115.8872\" y=\"221.0605\">[Route</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"12\" lengthAdjust=\"spacing\" textLength=\"3.8145\" x=\"155.9419\" y=\"221.0605\">&#160;</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"12\" lengthAdjust=\"spacing\" textLength=\"19.9512\" x=\"159.7563\" y=\"221.0605\">53]</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"145.5723\" y=\"236.8857\">&#160;</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"48.5625\" x=\"56.5\" y=\"253.1826\">Routes</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"105.0625\" y=\"253.1826\">&#160;</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"64.3125\" x=\"109.5127\" y=\"253.1826\">incoming</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"173.8252\" y=\"253.1826\">&#160;</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"60.8193\" x=\"178.2754\" y=\"253.1826\">requests</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"42.2598\" x=\"126.6675\" y=\"269.4795\">based</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"35.1982\" x=\"77.4556\" y=\"285.7764\">upon</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"112.6538\" y=\"285.7764\">&#160;</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"52.4316\" x=\"117.104\" y=\"285.7764\">domain</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"169.5356\" y=\"285.7764\">&#160;</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"44.1533\" x=\"173.9858\" y=\"285.7764\">name.</text></g><!--entity Default.AmazonWebServices.apsoutheast1.LoadBalancer--><g id=\"elem_Default.AmazonWebServices.apsoutheast1.LoadBalancer\"><rect fill=\"#FFFFFF\" height=\"101.4844\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#A2A2A2;stroke-width:0.5;\" width=\"216.1572\" x=\"59\" y=\"388.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"43.4375\" x=\"103.1294\" y=\"413.1484\">Load</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"5.5703\" x=\"146.5669\" y=\"413.1484\">&#160;</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"78.8906\" x=\"152.1372\" y=\"413.1484\">Balancer</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"12\" lengthAdjust=\"spacing\" textLength=\"43.8398\" x=\"98.1079\" y=\"428.0605\">[Elastic</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"12\" lengthAdjust=\"spacing\" textLength=\"3.8145\" x=\"141.9478\" y=\"428.0605\">&#160;</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"12\" lengthAdjust=\"spacing\" textLength=\"28.998\" x=\"145.7622\" y=\"428.0605\">Load</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"12\" lengthAdjust=\"spacing\" textLength=\"3.8145\" x=\"174.7603\" y=\"428.0605\">&#160;</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"12\" lengthAdjust=\"spacing\" textLength=\"57.4746\" x=\"178.5747\" y=\"428.0605\">Balancer]</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"164.8535\" y=\"443.8857\">&#160;</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"96.4414\" x=\"79.4521\" y=\"460.1826\">Automatically</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"175.8936\" y=\"460.1826\">&#160;</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"74.3613\" x=\"180.3438\" y=\"460.1826\">distributes</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"64.3125\" x=\"69\" y=\"476.4795\">incoming</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"133.3125\" y=\"476.4795\">&#160;</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"77.2256\" x=\"137.7627\" y=\"476.4795\">application</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"214.9883\" y=\"476.4795\">&#160;</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"45.7188\" x=\"219.4385\" y=\"476.4795\">traffic.</text></g><!--entity Default.AmazonWebServices.apsoutheast1.AmazonRDS.MySQL.DatabaseSchema_1--><g id=\"elem_Default.AmazonWebServices.apsoutheast1.AmazonRDS.MySQL.DatabaseSchema_1\"><path d=\"M305.5,226.2969 C305.5,216.2969 396.2188,216.2969 396.2188,216.2969 C396.2188,216.2969 486.9375,216.2969 486.9375,226.2969 L486.9375,253.9219 C486.9375,263.9219 396.2188,263.9219 396.2188,263.9219 C396.2188,263.9219 305.5,263.9219 305.5,253.9219 L305.5,226.2969 \" fill=\"#438DD5\" style=\"stroke:#3C7FC0;stroke-width:0.5;\"/><path d=\"M305.5,226.2969 C305.5,236.2969 396.2188,236.2969 396.2188,236.2969 C396.2188,236.2969 486.9375,236.2969 486.9375,226.2969 \" fill=\"none\" style=\"stroke:#3C7FC0;stroke-width:0.5;\"/><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"85.1484\" x=\"315.5\" y=\"255.1484\">Database</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"5.5703\" x=\"400.6484\" y=\"255.1484\">&#160;</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"70.7188\" x=\"406.2188\" y=\"255.1484\">Schema</text></g><!--entity Default.AmazonWebServices.apsoutheast1.AutoscalingGroup.AmazonEC2UbuntuServer.WebApplication_1--><g id=\"elem_Default.AmazonWebServices.apsoutheast1.AutoscalingGroup.AmazonEC2UbuntuServer.WebApplication_1\"><rect fill=\"#438DD5\" height=\"52.5938\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#3C7FC0;stroke-width:0.5;\" width=\"167.5781\" x=\"95\" y=\"632.2969\"/><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"39.9531\" x=\"105\" y=\"657.1484\">Web</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"5.5703\" x=\"144.9531\" y=\"657.1484\">&#160;</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"102.0547\" x=\"150.5234\" y=\"657.1484\">Application</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"30.0293\" x=\"111.5586\" y=\"672.0605\">[Java</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"3.8145\" x=\"141.5879\" y=\"672.0605\">&#160;</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"22.5762\" x=\"145.4023\" y=\"672.0605\">and</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"3.8145\" x=\"167.9785\" y=\"672.0605\">&#160;</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"38.7246\" x=\"171.793\" y=\"672.0605\">Spring</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"3.8145\" x=\"210.5176\" y=\"672.0605\">&#160;</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"31.6875\" x=\"214.332\" y=\"672.0605\">boot]</text></g><!--link Default.AmazonWebServices.apsoutheast1.DNSRouter to Default.AmazonWebServices.apsoutheast1.LoadBalancer--><g id=\"link_Default.AmazonWebServices.apsoutheast1.DNSRouter_Default.AmazonWebServices.apsoutheast1.LoadBalancer\"><path d=\"M153.62,299.4569 C156.35,327.6369 158.8223,353.1638 161.4223,380.1338 \" fill=\"none\" id=\"Default.AmazonWebServices.apsoutheast1.DNSRouter-to-Default.AmazonWebServices.apsoutheast1.LoadBalancer\" style=\"stroke:#666666;stroke-width:1;\"/><polygon fill=\"#666666\" points=\"162.19,388.0969,164.4085,379.8459,158.4362,380.4217,162.19,388.0969\" style=\"stroke:#666666;stroke-width:1;\"/><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"57.2754\" x=\"161\" y=\"341.4355\">Fowards</text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"218.2754\" y=\"341.4355\">&#160;</text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"59.3496\" x=\"222.4531\" y=\"341.4355\">requests</text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"281.8027\" y=\"341.4355\">&#160;</text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"13.9805\" x=\"285.9805\" y=\"341.4355\">to</text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"40.2832\" x=\"210.3389\" y=\"355.4043\">[HTTP]</text></g><!--link Default.AmazonWebServices.apsoutheast1.LoadBalancer to Default.AmazonWebServices.apsoutheast1.AutoscalingGroup.AmazonEC2UbuntuServer.WebApplication_1--><g id=\"link_Default.AmazonWebServices.apsoutheast1.LoadBalancer_Default.AmazonWebServices.apsoutheast1.AutoscalingGroup.AmazonEC2UbuntuServer.WebApplication_1\"><path d=\"M169.74,489.5369 C172.18,533.8969 175.2213,589.0789 177.1413,624.0389 \" fill=\"none\" id=\"Default.AmazonWebServices.apsoutheast1.LoadBalancer-to-Default.AmazonWebServices.apsoutheast1.AutoscalingGroup.AmazonEC2UbuntuServer.WebApplication_1\" style=\"stroke:#666666;stroke-width:1;\"/><polygon fill=\"#666666\" points=\"177.58,632.0269,180.1368,623.8744,174.1458,624.2034,177.58,632.0269\" style=\"stroke:#666666;stroke-width:1;\"/><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"63.1934\" x=\"173\" y=\"531.4355\">Forwards</text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"236.1934\" y=\"531.4355\">&#160;</text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"59.3496\" x=\"240.3711\" y=\"531.4355\">requests</text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"299.7207\" y=\"531.4355\">&#160;</text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"13.9805\" x=\"303.8984\" y=\"531.4355\">to</text></g><!--link Default.AmazonWebServices.useast1.DNSRouter to Default.AmazonWebServices.useast1.LoadBalancer--><g id=\"link_Default.AmazonWebServices.useast1.DNSRouter_Default.AmazonWebServices.useast1.LoadBalancer\"><path d=\"M697.62,299.4569 C700.35,327.6369 702.8223,353.1638 705.4223,380.1338 \" fill=\"none\" id=\"Default.AmazonWebServices.useast1.DNSRouter-to-Default.AmazonWebServices.useast1.LoadBalancer\" style=\"stroke:#666666;stroke-width:1;\"/><polygon fill=\"#666666\" points=\"706.19,388.0969,708.4085,379.8459,702.4362,380.4217,706.19,388.0969\" style=\"stroke:#666666;stroke-width:1;\"/><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"57.2754\" x=\"704\" y=\"341.4355\">Fowards</text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"761.2754\" y=\"341.4355\">&#160;</text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"59.3496\" x=\"765.4531\" y=\"341.4355\">requests</text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"824.8027\" y=\"341.4355\">&#160;</text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"13.9805\" x=\"828.9805\" y=\"341.4355\">to</text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"40.2832\" x=\"753.3389\" y=\"355.4043\">[HTTP]</text></g><!--link Default.AmazonWebServices.useast1.LoadBalancer to Default.AmazonWebServices.useast1.AutoscalingGroup.AmazonEC2UbuntuServer.WebApplication_1--><g id=\"link_Default.AmazonWebServices.useast1.LoadBalancer_Default.AmazonWebServices.useast1.AutoscalingGroup.AmazonEC2UbuntuServer.WebApplication_1\"><path d=\"M713.74,489.5369 C716.18,533.8969 719.2213,589.0789 721.1413,624.0389 \" fill=\"none\" id=\"Default.AmazonWebServices.useast1.LoadBalancer-to-Default.AmazonWebServices.useast1.AutoscalingGroup.AmazonEC2UbuntuServer.WebApplication_1\" style=\"stroke:#666666;stroke-width:1;\"/><polygon fill=\"#666666\" points=\"721.58,632.0269,724.1368,623.8744,718.1458,624.2034,721.58,632.0269\" style=\"stroke:#666666;stroke-width:1;\"/><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"63.1934\" x=\"716\" y=\"531.4355\">Forwards</text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"779.1934\" y=\"531.4355\">&#160;</text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"59.3496\" x=\"783.3711\" y=\"531.4355\">requests</text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"842.7207\" y=\"531.4355\">&#160;</text><text fill=\"#666666\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"13.9805\" x=\"846.8984\" y=\"531.4355\">to</text></g><rect fill=\"none\" height=\"16.2969\" style=\"stroke:none;stroke-width:1;\" width=\"96.291\" x=\"997.709\" y=\"797.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"57.9209\" x=\"997.709\" y=\"810.292\">Legend</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"1060.5039\" y=\"810.292\">&#160;</text><rect fill=\"#438DD5\" height=\"16.2969\" style=\"stroke:none;stroke-width:1;\" width=\"96.291\" x=\"997.709\" y=\"813.5938\"/><text fill=\"#3C7FC0\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"7.7041\" x=\"1002.1592\" y=\"826.5889\">&#9647;</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"1009.8633\" y=\"826.5889\">&#160;</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"66.3359\" x=\"1018.7637\" y=\"826.5889\">container</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"1089.5498\" y=\"826.5889\">&#160;</text><rect fill=\"#FFFFFF\" height=\"16.2969\" style=\"stroke:none;stroke-width:1;\" width=\"96.291\" x=\"997.709\" y=\"829.8906\"/><text fill=\"#A2A2A2\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"7.7041\" x=\"1002.1592\" y=\"842.8857\">&#9647;</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"1009.8633\" y=\"842.8857\">&#160;</text><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"34.9385\" x=\"1018.7637\" y=\"842.8857\">node</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"1058.1523\" y=\"842.8857\">&#160;</text><line style=\"stroke:none;stroke-width:1;\" x1=\"997.709\" x2=\"1094\" y1=\"797.2969\" y2=\"797.2969\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"997.709\" x2=\"1094\" y1=\"813.5938\" y2=\"813.5938\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"997.709\" x2=\"1094\" y1=\"829.8906\" y2=\"829.8906\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"997.709\" x2=\"1094\" y1=\"846.1875\" y2=\"846.1875\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"997.709\" x2=\"997.709\" y1=\"797.2969\" y2=\"846.1875\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"1094\" x2=\"1094\" y1=\"797.2969\" y2=\"846.1875\"/><!--SRC=[rLRRRjD047ttLmmH3wtK61NA6wqKuhGL2W7YeZv6OtlIMDYxPdUs413_pjfEQeUceJ7D1Scovs9dpbpEPZGnQCfG8Ki5GWfoEEQ4e9FY3odWcWBmITt68MdmA4laD2N1ZiCo0vOGI6QPGXGh2ZcMmd6UnI9CJ4JmfdloedjozgTXr9M2wJilTs0iIDrtLP7F7ATIHWCPqO57OpG9koLaYtWE-0XQIz9e7S5pdcPqsigbY7IeIf7nHfTI4eilLZg4dmx0eyEvHXDgFhPXZMxdOljutM0DmhaTmrA7Q7_dva99a-LfLoOeRElZU0eairTxtPUV0oFOv1-GgjfY7T26qWUbimbGWBlHUJAGhlsqasL9768-rwEyg_aKrMm5AWeduhJr3cyHK4JWPoglUI0b_nN_3Fqlnwaz6XIzy0mzlwghLRRKy7biz_tK_zIt28hdFpRH2zOFxNh86A0cFvnGYaM_vYOeRRL-RQitti0VIiF5p5iPIgKgJw73wrSrF8L9Wpq0PPgFagAlXZHho3E9m6Islv5CRQ50O4hk2lphu-rBZDvYWY8i8ESgpFKATI-nBySXt7FFKiWPbbgAM98bK_lVe5d5mM9MMD48ME5u78SFPrAK__79OAPj3IVpinYpzfs-sGEv7dWdj5mEO7lSN1L_lmYwWFH_OUa2wFsaQlDftVaIinBENcqo3P3kPfsnDtiDAMd0n6OqE9VVK4MwuYFBMbwNLrSV7m2_1iZ5a1jlqxbKgt9gbC-I_MJjvM13fLuURPDhVRC2E_xbX-jHltVH6tW7h0mT_WO0]--></g></svg>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "<buildzr.dsl.dsl.Workspace at 0xe1fc13f76bf0>"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {
-      "application/json": {
-       "expanded": false,
-       "root": "workspace"
-      }
-     },
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Simply evaluate the workspace - Jupyter will call _repr_html_() automatically\n",
     "w"

--- a/examples/amazon_web_services.ipynb
+++ b/examples/amazon_web_services.ipynb
@@ -13,14 +13,25 @@
   },
   {
    "cell_type": "code",
-   "source": "from buildzr.__about__ import VERSION\nprint(f\"buildzr version: {VERSION}\")",
+   "execution_count": 15,
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "buildzr version: 0.0.30\n"
+     ]
+    }
+   ],
+   "source": [
+    "from buildzr.__about__ import VERSION\n",
+    "print(f\"buildzr version: {VERSION}\")"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -52,9 +63,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exported: output/web_app_system_context_00.puml\n",
+      "Exported: output/web_app_container_view_00.puml\n",
+      "Exported: output/web_app_system_context_00.puml\n",
+      "Rendered: output/web_app_system_context_00.svg\n",
+      "Exported: output/web_app_container_view_00.puml\n",
+      "Rendered: output/web_app_container_view_00.svg\n"
+     ]
+    }
+   ],
    "source": [
     "from buildzr.dsl import (\n",
     "    Workspace,\n",
@@ -77,7 +101,7 @@
     "        u = Person('Web Application User')\n",
     "        webapp = SoftwareSystem('Corporate Web App')\n",
     "        with webapp:\n",
-    "            database = Container('database', tags={'db'})\n",
+    "            database = Container('database')\n",
     "            api = Container('api')\n",
     "            api >> (\"Reads and writes data from/to\", \"http/api\") >> database\n",
     "    with Group(\"Microsoft\") as microsoft:\n",
@@ -105,13 +129,9 @@
     "        description=\"Web App Container View\",\n",
     "    )\n",
     "\n",
-    "    # Stylize the views.\n",
+    "    # Stylize the views, and apply AWS theme icons.\n",
     "\n",
-    "    StyleElements(on=['db'], shape='Cylinder')\n",
-    "\n",
-    "    # Apply AWS theme icons.\n",
-    "\n",
-    "    StyleElements(on=[u], shape='Person', **AWS.USER)\n",
+    "    StyleElements(on=[u], **AWS.USER)\n",
     "    StyleElements(on=[api], **AWS.LAMBDA)\n",
     "    StyleElements(on=[database], **AWS.RDS)\n",
     "\n",
@@ -134,9 +154,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Workspace: w\n",
+      "Description: \n",
+      "Number of views: 1\n"
+     ]
+    }
+   ],
    "source": [
     "# Get workspace as dictionary\n",
     "data = w.to_dict()\n",
@@ -147,20 +177,134 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'id': 3,\n",
+       " 'name': 'w',\n",
+       " 'description': '',\n",
+       " 'model': {'people': [{'id': '19',\n",
+       "    'name': 'Web Application User',\n",
+       "    'description': '',\n",
+       "    'tags': 'Amazon Web Services - User,Person,Element',\n",
+       "    'location': 'Unspecified',\n",
+       "    'group': 'My Company',\n",
+       "    'properties': {},\n",
+       "    'relationships': [{'id': '25',\n",
+       "      'description': 'Reads and writes email using',\n",
+       "      'tags': 'Relationship',\n",
+       "      'sourceId': '19',\n",
+       "      'destinationId': '24'},\n",
+       "     {'id': '26',\n",
+       "      'description': 'Create work order using',\n",
+       "      'tags': 'Relationship',\n",
+       "      'sourceId': '19',\n",
+       "      'destinationId': '20'}]}],\n",
+       "  'softwareSystems': [{'id': '20',\n",
+       "    'name': 'Corporate Web App',\n",
+       "    'description': '',\n",
+       "    'location': 'Unspecified',\n",
+       "    'tags': 'Software System,Element',\n",
+       "    'containers': [{'id': '21',\n",
+       "      'name': 'database',\n",
+       "      'description': '',\n",
+       "      'technology': '',\n",
+       "      'tags': 'Container,Amazon Web Services - RDS,Element',\n",
+       "      'components': [],\n",
+       "      'group': 'My Company',\n",
+       "      'properties': {},\n",
+       "      'relationships': []},\n",
+       "     {'id': '22',\n",
+       "      'name': 'api',\n",
+       "      'description': '',\n",
+       "      'technology': '',\n",
+       "      'tags': 'Amazon Web Services - Lambda,Container,Element',\n",
+       "      'components': [],\n",
+       "      'group': 'My Company',\n",
+       "      'properties': {},\n",
+       "      'relationships': [{'id': '23',\n",
+       "        'description': 'Reads and writes data from/to',\n",
+       "        'tags': 'Relationship',\n",
+       "        'sourceId': '22',\n",
+       "        'destinationId': '21',\n",
+       "        'technology': 'http/api'}]}],\n",
+       "    'group': 'My Company',\n",
+       "    'properties': {},\n",
+       "    'relationships': [{'id': '27',\n",
+       "      'description': 'sends notification using',\n",
+       "      'tags': 'Relationship',\n",
+       "      'sourceId': '20',\n",
+       "      'destinationId': '24',\n",
+       "      'technology': ''}],\n",
+       "    'documentation': {}},\n",
+       "   {'id': '24',\n",
+       "    'name': 'Microsoft 365',\n",
+       "    'description': '',\n",
+       "    'location': 'Unspecified',\n",
+       "    'tags': 'Software System,Element',\n",
+       "    'containers': [],\n",
+       "    'group': 'Microsoft',\n",
+       "    'properties': {},\n",
+       "    'relationships': [],\n",
+       "    'documentation': {}}],\n",
+       "  'deploymentNodes': [],\n",
+       "  'properties': {'structurizr.groupSeparator': '/'}},\n",
+       " 'views': {'systemContextViews': [{'key': 'web_app_system_context_00',\n",
+       "    'order': 1,\n",
+       "    'description': 'Web App System Context',\n",
+       "    'softwareSystemId': '20',\n",
+       "    'automaticLayout': {'implementation': 'Graphviz',\n",
+       "     'rankDirection': 'LeftRight',\n",
+       "     'rankSeparation': 300,\n",
+       "     'nodeSeparation': 300,\n",
+       "     'edgeSeparation': 0,\n",
+       "     'vertices': False,\n",
+       "     'applied': False},\n",
+       "    'enterpriseBoundaryVisible': True,\n",
+       "    'elements': [{'id': '19', 'x': 0, 'y': 0},\n",
+       "     {'id': '20', 'x': 0, 'y': 0},\n",
+       "     {'id': '24', 'x': 0, 'y': 0}],\n",
+       "    'relationships': [{'id': '26'}, {'id': '27'}]}],\n",
+       "  'containerViews': [{'key': 'web_app_container_view_00',\n",
+       "    'description': 'Web App Container View',\n",
+       "    'softwareSystemId': '20',\n",
+       "    'automaticLayout': {'implementation': 'Graphviz',\n",
+       "     'rankDirection': 'LeftRight',\n",
+       "     'rankSeparation': 300,\n",
+       "     'nodeSeparation': 300,\n",
+       "     'edgeSeparation': 0,\n",
+       "     'vertices': False},\n",
+       "    'elements': [{'id': '21', 'x': 0, 'y': 0}, {'id': '22', 'x': 0, 'y': 0}],\n",
+       "    'relationships': [{'id': '23'}]}],\n",
+       "  'configuration': {'styles': {'elements': [{'tag': 'Amazon Web Services - User',\n",
+       "      'stroke': '#242f3e',\n",
+       "      'color': '#242f3e',\n",
+       "      'icon': 'https://static.structurizr.com/themes/amazon-web-services-2023.01.31/Res_User_48_Light.png'},\n",
+       "     {'tag': 'Amazon Web Services - Lambda',\n",
+       "      'stroke': '#e2730e',\n",
+       "      'color': '#e2730e',\n",
+       "      'icon': 'https://static.structurizr.com/themes/amazon-web-services-2023.01.31/Arch_AWS-Lambda_48.png'},\n",
+       "     {'tag': 'Amazon Web Services - RDS',\n",
+       "      'stroke': '#3f51d4',\n",
+       "      'color': '#3f51d4',\n",
+       "      'icon': 'https://static.structurizr.com/themes/amazon-web-services-2023.01.31/Arch_Amazon-RDS_48.png'}]},\n",
+       "   'branding': {},\n",
+       "   'terminology': {},\n",
+       "   'properties': {'c4plantuml.tags': 'true'}}},\n",
+       " 'documentation': {},\n",
+       " 'configuration': {'scope': 'SoftwareSystem'}}"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "w.to_dict()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## View as PlantUML\n",
-    "\n",
-    "Get the PlantUML source for all views."
    ]
   },
   {
@@ -174,9 +318,58 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<h3>web_app_system_context_00</h3>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" contentStyleType=\"text/css\" height=\"498px\" preserveAspectRatio=\"none\" style=\"width:399px;height:498px;background:#FFFFFF;\" version=\"1.1\" viewBox=\"0 0 399 498\" width=\"399px\" zoomAndPan=\"magnify\"><title>Corporate Web App - System Context</title><defs/><g><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"295.0801\" x=\"45.1748\" y=\"22.9951\">Corporate Web App - System Context</text><!--entity WebApplicationUser--><g id=\"elem_WebApplicationUser\"><rect fill=\"#DDDDDD\" height=\"68.625\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#9A9A9A;stroke-width:0.5;\" width=\"214.4063\" x=\"83.5\" y=\"44.2969\"/><image height=\"30\" width=\"30\" x=\"175.7031\" xlink:href=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAYAAAA7MK6iAAADU0lEQVR4XtWW3UtTcRjHt7M39+KcO8dtZ247Z9vZcZt7OXvR5tIdF0aIlAgF1WV4YRBRgSB0E9lN4k1/g3kVZHeBRhR0VzfRTRfdFoSiYpGKQT3PKKFHD+7Fgj7wwOF8v8/znN/2e9Pp/hekdHkg3FtaDCdL72oBz1KmXKa+Y4MXk4OxrPoypqifIR7JxZE5DHyuvQONDycHaV4L6HWBSHo0plR20idGnrg8IZY68B1oS+gJRjKjOr1eTz0NE0+c9ErZysdgLD8XlSQT1X+DWkDOzaEXc6jeEFarVScp6iL8lM9FUWSoThEEgUEvNH9os9maHzXHiyEosut0e09TTQv0Yk6XPxyiWt24fcJZKLJp72BFqmmBXsxhfeI5qtUNNL4CRdYcTs5NNS0cTtYNOauYS7W6cXuFS1Bk3e5keappgV7MgRFfplrduL1iAYpsB0Wpj2paoBdzWJ9QoFrdMIwBZmnldU9BvU81LeLgxRzGYDBQrSE4v9QPhdbCysAYYzRSeR/U0INezKF6wxiNZr2cHZrHSSYXhgfMZsuBTcRssZhQq3mylXnMoZ6maHO0mxPF6jQU3koVqyt8JDXlj6TLGPic6ju1jFq8UJ1GL81vCXsH1x1Nl2/BYbAHTX6Q2ItkBqftTi5I85rGYDSbxNQA7sEbEN8hnsH/eLtHqV6Qlep4TBm+LimVp9gcPXBMPoCc1kYdkvNnoNh7GOXbSKZ/iuUFzfXs8Ue4RKZ/EvbqN+D/EIwp49RzJHo9w0RT5Yswkm9STl2wt7MW6tHC5nRbYzl1CT54B2tAqSMPl32EeGECErd9QuKajePqT/yFo7PTeHPm7g1sDrXOU/1QgsmUBCNdTRXVWao1Sjyr4txYD/bkE1T7A1h/JikztCzn1Bc2m6O1CQK0WR3WWLbyKpodWjGYzAfW/z6eQKQXjBtBWSlRrVn8kpKHUW92+aNZqtXArRVm42OYlYtUaxW4xSxA3aVDt29Pt8jBl+2yvNj4MjgC1h8ew8nq7Q77qAaHvjgC4hacpzLVWgVrYm04Kg9eoeDGMAniGlxdOKq1it3FunClQOOrVMPGeAh85cXEPXi+c5wB+8Es1P4Cv+oM7atzdQUmxGTp09+MTk9ggvb95/wEFH7u7EgAMNMAAAAASUVORK5CYII=\" y=\"54.2969\"/><text fill=\"#242F3E\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"39.9531\" x=\"93.5\" y=\"99.1484\">Web</text><text fill=\"#242F3E\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"5.5703\" x=\"133.4531\" y=\"99.1484\"> </text><text fill=\"#242F3E\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"102.0547\" x=\"139.0234\" y=\"99.1484\">Application</text><text fill=\"#242F3E\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"5.5703\" x=\"241.0781\" y=\"99.1484\"> </text><text fill=\"#242F3E\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"41.2578\" x=\"246.6484\" y=\"99.1484\">User</text></g><!--entity CorporateWebApp--><g id=\"elem_CorporateWebApp\"><rect fill=\"#1168BD\" height=\"38.625\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#3C7FC0;stroke-width:0.5;\" width=\"196.6406\" x=\"7\" y=\"202.2969\"/><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"90.2578\" x=\"17\" y=\"227.1484\">Corporate</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"5.5703\" x=\"107.2578\" y=\"227.1484\"> </text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"39.9531\" x=\"112.8281\" y=\"227.1484\">Web</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"5.5703\" x=\"152.7813\" y=\"227.1484\"> </text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"35.2891\" x=\"158.3516\" y=\"227.1484\">App</text></g><!--entity Microsoft365--><g id=\"elem_Microsoft365\"><rect fill=\"#1168BD\" height=\"38.625\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#3C7FC0;stroke-width:0.5;\" width=\"143.8672\" x=\"118.5\" y=\"330.2969\"/><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"84.8984\" x=\"128.5\" y=\"355.1484\">Microsoft</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"5.5703\" x=\"213.3984\" y=\"355.1484\"> </text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"33.3984\" x=\"218.9688\" y=\"355.1484\">365</text></g><!--link WebApplicationUser to Microsoft365--><g id=\"link_WebApplicationUser_Microsoft365\"><path d=\"M232.48,113.4069 C240.63,122.1869 248.03,132.3069 252.5,143.2969 C278.82,207.9169 283.07,237.5669 252.5,300.2969 C246.57,312.4569 242.4719,317.8198 231.6819,325.5198 \" fill=\"none\" id=\"WebApplicationUser-to-Microsoft365\" style=\"stroke:#707070;stroke-width:1;\"/><polygon fill=\"#707070\" points=\"225.17,330.1669,233.4246,327.9618,229.9393,323.0779,225.17,330.1669\" style=\"stroke:#707070;stroke-width:1;\"/><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"41.209\" x=\"274.5\" y=\"219.4355\">Reads</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"315.709\" y=\"219.4355\"> </text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"25.2305\" x=\"319.8867\" y=\"219.4355\">and</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"345.1172\" y=\"219.4355\"> </text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"42.1348\" x=\"349.2949\" y=\"219.4355\">writes</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"36.9668\" x=\"293.9268\" y=\"233.4043\">email</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"330.8936\" y=\"233.4043\"> </text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"36.9316\" x=\"335.0713\" y=\"233.4043\">using</text></g><!--link WebApplicationUser to CorporateWebApp--><g id=\"link_WebApplicationUser_CorporateWebApp\"><path d=\"M147.38,113.4769 C138.36,122.3169 129.71,132.4469 123.5,143.2969 C113,161.6369 109.5013,177.7856 107.6813,194.2056 \" fill=\"none\" id=\"WebApplicationUser-to-CorporateWebApp\" style=\"stroke:#707070;stroke-width:1;\"/><polygon fill=\"#707070\" points=\"106.8,202.1569,110.6631,194.5361,104.6996,193.8751,106.8,202.1569\" style=\"stroke:#707070;stroke-width:1;\"/><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"44.8359\" x=\"124.5\" y=\"155.4355\">Create</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"169.3359\" y=\"155.4355\"> </text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"33.2285\" x=\"173.5137\" y=\"155.4355\">work</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"206.7422\" y=\"155.4355\"> </text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"36.8086\" x=\"210.9199\" y=\"155.4355\">order</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"36.9316\" x=\"167.6484\" y=\"169.4043\">using</text></g><!--link CorporateWebApp to Microsoft365--><g id=\"link_CorporateWebApp_Microsoft365\"><path d=\"M106.82,241.4369 C108.76,258.0969 113.57,282.5269 125.5,300.2969 C133.5,312.2169 138.8508,317.8247 150.3208,325.6847 \" fill=\"none\" id=\"CorporateWebApp-to-Microsoft365\" style=\"stroke:#707070;stroke-width:1;\"/><polygon fill=\"#707070\" points=\"156.92,330.2069,152.0166,323.21,148.625,328.1594,156.92,330.2069\" style=\"stroke:#707070;stroke-width:1;\"/><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"39.5566\" x=\"126.5\" y=\"283.4355\">sends</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"166.0566\" y=\"283.4355\"> </text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"77.8184\" x=\"170.2344\" y=\"283.4355\">notification</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"36.9316\" x=\"168.8105\" y=\"297.4043\">using</text></g><rect fill=\"none\" height=\"16.2969\" style=\"stroke:none;stroke-width:1;\" width=\"297.1621\" x=\"71.2676\" y=\"392.9219\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"57.9209\" x=\"71.2676\" y=\"405.917\">Legend</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"134.0625\" y=\"405.917\"> </text><rect fill=\"#1168BD\" height=\"16.2969\" style=\"stroke:none;stroke-width:1;\" width=\"297.1621\" x=\"71.2676\" y=\"409.2188\"/><text fill=\"#3C7FC0\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"7.7041\" x=\"75.7178\" y=\"422.2139\"/><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"83.4219\" y=\"422.2139\"> </text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"50.6133\" x=\"92.3223\" y=\"422.2139\">system</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"147.3857\" y=\"422.2139\"> </text><rect fill=\"#DDDDDD\" height=\"30\" style=\"stroke:none;stroke-width:1;\" width=\"297.1621\" x=\"71.2676\" y=\"425.5156\"/><text fill=\"#9A9A9A\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"7.7041\" x=\"75.7178\" y=\"452.2139\"/><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"83.4219\" y=\"452.2139\"> </text><image height=\"30\" width=\"30\" x=\"87.8721\" xlink:href=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAYAAAA7MK6iAAADU0lEQVR4XtWW3UtTcRjHt7M39+KcO8dtZ247Z9vZcZt7OXvR5tIdF0aIlAgF1WV4YRBRgSB0E9lN4k1/g3kVZHeBRhR0VzfRTRfdFoSiYpGKQT3PKKFHD+7Fgj7wwOF8v8/znN/2e9Pp/hekdHkg3FtaDCdL72oBz1KmXKa+Y4MXk4OxrPoypqifIR7JxZE5DHyuvQONDycHaV4L6HWBSHo0plR20idGnrg8IZY68B1oS+gJRjKjOr1eTz0NE0+c9ErZysdgLD8XlSQT1X+DWkDOzaEXc6jeEFarVScp6iL8lM9FUWSoThEEgUEvNH9os9maHzXHiyEosut0e09TTQv0Yk6XPxyiWt24fcJZKLJp72BFqmmBXsxhfeI5qtUNNL4CRdYcTs5NNS0cTtYNOauYS7W6cXuFS1Bk3e5keappgV7MgRFfplrduL1iAYpsB0Wpj2paoBdzWJ9QoFrdMIwBZmnldU9BvU81LeLgxRzGYDBQrSE4v9QPhdbCysAYYzRSeR/U0INezKF6wxiNZr2cHZrHSSYXhgfMZsuBTcRssZhQq3mylXnMoZ6maHO0mxPF6jQU3koVqyt8JDXlj6TLGPic6ju1jFq8UJ1GL81vCXsH1x1Nl2/BYbAHTX6Q2ItkBqftTi5I85rGYDSbxNQA7sEbEN8hnsH/eLtHqV6Qlep4TBm+LimVp9gcPXBMPoCc1kYdkvNnoNh7GOXbSKZ/iuUFzfXs8Ue4RKZ/EvbqN+D/EIwp49RzJHo9w0RT5Yswkm9STl2wt7MW6tHC5nRbYzl1CT54B2tAqSMPl32EeGECErd9QuKajePqT/yFo7PTeHPm7g1sDrXOU/1QgsmUBCNdTRXVWao1Sjyr4txYD/bkE1T7A1h/JikztCzn1Bc2m6O1CQK0WR3WWLbyKpodWjGYzAfW/z6eQKQXjBtBWSlRrVn8kpKHUW92+aNZqtXArRVm42OYlYtUaxW4xSxA3aVDt29Pt8jBl+2yvNj4MjgC1h8ew8nq7Q77qAaHvjgC4hacpzLVWgVrYm04Kg9eoeDGMAniGlxdOKq1it3FunClQOOrVMPGeAh85cXEPXi+c5wB+8Es1P4Cv+oM7atzdQUmxGTp09+MTk9ggvb95/wEFH7u7EgAMNMAAAAASUVORK5CYII=\" y=\"425.5156\"/><text fill=\"#242F3E\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"201.7217\" x=\"126.7725\" y=\"452.2139\">Amazon Web Services - User</text><text fill=\"#242F3E\" font-family=\"sans-serif\" font-size=\"10\" lengthAdjust=\"spacing\" textLength=\"31.0352\" x=\"332.9443\" y=\"453.1572\">(solid)</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"363.9795\" y=\"452.2139\"> </text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"8.4287\" x=\"75.7178\" y=\"468.5107\">─</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"84.1465\" y=\"468.5107\"> </text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"86.5703\" x=\"93.0469\" y=\"468.5107\">Relationship</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"184.0674\" y=\"468.5107\"> </text><line style=\"stroke:none;stroke-width:1;\" x1=\"71.2676\" x2=\"368.4297\" y1=\"392.9219\" y2=\"392.9219\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"71.2676\" x2=\"368.4297\" y1=\"409.2188\" y2=\"409.2188\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"71.2676\" x2=\"368.4297\" y1=\"425.5156\" y2=\"425.5156\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"71.2676\" x2=\"368.4297\" y1=\"455.5156\" y2=\"455.5156\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"71.2676\" x2=\"368.4297\" y1=\"471.8125\" y2=\"471.8125\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"71.2676\" x2=\"71.2676\" y1=\"392.9219\" y2=\"471.8125\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"368.4297\" x2=\"368.4297\" y1=\"392.9219\" y2=\"471.8125\"/><!--SRC=[dLDTRzCm57tFhxW47ZffJRgs6p2HILMfu643r8Bs6BdsRM8jiIFVMyg6-E-pqmzG5mHQ_13v93dd-9mRGWR2HZZ1re6n1YFMN25ChMkiHn5kSGcJfe4-BEw9iVQF3ECFZYAs3R25fMMsDIZjKBAs9efUQ2EhjK9uDnsdq_7LCP3lAAwYQABKhC8Q3NyLHI-UrEB1cbPpWUwxbaXU-1kXYq_XrRAOsigwB7wfsgl5h5FezlXR4LR0LrvYZmx7mzK80qgDqunPhElYicHkw39DYGLhcH2xjUIrqmykaRPEkVIsA1Mje_u6bttQEUeF1yDHCZXBHcVf72aFzlBnc_nQ5oKdZIb-aXGLPeFaOdZ-gvKjXR8RROei_krvmVV-fPXifLLyqaOnnwgDmTz5Y99AtOGFGbZxmxmUX1NGIXliHbjgo20El5_GaJKzdwcliTAoPGwUJo7UbRj73qah9EcsPbaKbFsZ6AzvbmMnxOZq3jEp5VL2J-QfKsKt2bsKDrewItR5eujpptVOWj__DrVaW-qCueXzZa8H2ADW4-Q506kXArYJht3RXopDdsB7XHqK_oROaP334C_6kZjev-EvSa-eZmv7QFpXZ6MzsjV-3ALeyV7pRNuz-p3xzBxdVnqyUGG0]--></g></svg>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.SVG object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<h3>web_app_container_view_00</h3>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" contentStyleType=\"text/css\" height=\"512px\" preserveAspectRatio=\"none\" style=\"width:363px;height:512px;background:#FFFFFF;\" version=\"1.1\" viewBox=\"0 0 363 512\" width=\"363px\" zoomAndPan=\"magnify\"><title>Corporate Web App - Containers</title><defs/><g><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"255.6162\" x=\"50.0024\" y=\"22.9951\">Corporate Web App - Containers</text><!--cluster CorporateWebApp_boundary--><g id=\"cluster_CorporateWebApp_boundary\"><rect fill=\"none\" height=\"308\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#444444;stroke-width:1;stroke-dasharray:7.0,7.0;\" width=\"192\" x=\"89.3105\" y=\"44.2969\"/><text fill=\"#444444\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"176.6406\" x=\"96.9902\" y=\"61.1484\">Corporate Web App</text><text fill=\"#444444\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"59.4551\" x=\"155.583\" y=\"76.0605\">[system]</text></g><!--entity CorporateWebApp.database--><g id=\"elem_CorporateWebApp.database\"><rect fill=\"#DDDDDD\" height=\"68.625\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#9A9A9A;stroke-width:0.5;\" width=\"103.3203\" x=\"108.8105\" y=\"267.2969\"/><image height=\"30\" width=\"30\" x=\"145.4707\" xlink:href=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAYAAAA7MK6iAAAHDUlEQVR4Xn2Wi0+UVxrGv39nN9164SIgd4YZ5g4IbQUHuYiAl7rVXVmr7rpZdbNJ26ibmrY2u62xpqamXa3GXqStVFERFRjuwoDjCDgMDMN9YODZ857znW++AS3JSQgEfvM87/NelMwtXcgq7kHWGz3IfrMP2W89QU5JPwylHhhcg8jd/hTG8mcwVrBX6YOpehimnSPIq3kBc50flt0BWPaMw7p3Ata3J2H7Ywj2d6ZgPzANx59n4Tw4D2f9Apx/CSP/8BLyj0RQcHQZSmZhJwieWdTN4L0CvpXgAzBs8yC3bIjDc8u9Al71HKYdw8hjcHOtgJt3SXgQ1n0qfD8D/2mWwefgODgn4IcY/N0lFDC4kpHfgVg4U6+D5+jgBM5lz0TwaoKP6uBjHG4h5Srctn9Kg5NyR/088gnOlCvpznak57s1uLBdVU62lwrl3PYyoVwPJ9vNtQxcNxZrO8HfEcrtB2a47aRcwBcZ2N4GgmcUCOVZRV3YUv0ERTv7UVzrQfGuQQ4n5RIua87hZHuNVD7GlZceCsJ1JATX0RDK/kZgqvkMVy9rrqTZHiPN3irgTHlhZQ/oa2x8Ee6eOf5ytvarNR9k8CEYVOUUtmjNR7XANbvD6BxYQmBymf+vsr9OacrtZD2DK2nWR0iztQq4ox2FFT0MuoTJUAQ7Dg4K29+imvfrbI/W3PQK+O6TQYSmlzncdXSK2R6FU82VVPNDpFoI/hhke2FFF9q7ZrHjwACCkxFUM3j2mxIeTbtsNamcbM+rHuHwPcfHMTm1jL3/nERn/xK3XJ92giuppgcgeJoKd7o60PQgxG3fsb+fK7eX97281aRyzXYfivaNcqV7Toxz5Z39i9h2OBjbaky9kpJ7H6l5BG/RlEvb051u2Fw9urT3oLp+CJ9cDODqzRC+bQjh3KUJ1BwZial50b4RlnimXm01Le1vB2FjcPoAHJxibMZmDldtt0p4G097RkEn6o97EQ6voHdgHh9/4cffT42wN4qPL46j1xNGeHEF777vjx0yNdGayz4nuADn3IWAk/KWGOUlNd3wB8Jwbu9GYGIJD9qmYS3rQ25JHwwlT2As7YepzAPnziG0984jEIxg97FRTM0so+6YX6u5HDJSOQ0ZJTm7CRK+mZSzmmfaH+FWUxDPni+gfG8vb7UAS/rJMz4Meuf5hwhNRfij74d8YfzrIz8HU82rDg3DO7yI+21zsNbq+1zArQyuJGXegQY33OO2X70xhhs3A1rgyPIA62vjG6vHq0g79bm53CPAusBdaZhGw905nXKacGK2K0kZv0IPz7I0Y2o6wpVHbW/l4IXwMi5fC+DEaR/qT3jZe4YTZ4Zx+foE+90KB+v7nAJHtjt2qWHTbB+DsintFgT8NpKz7iDddA9z8xHk2B8weDOHk3KaZNatbvzjAy8+v/QC136cwPWbQZy/zD7Iv4fhrBrgYP1KNVc+xdzCCqzVvjUrVdmU+gsIvildwpvw/hkPenpnYHC0qIF7yMF1B/u0VqM+19u+54iX11v2uaVyEO4+1gFfTrx0pSqJKT8jCm/k8BRm+3unPZiZjeC/F3xIt7RwsH8szKbZEry+BXT2zvLnfc5+xoYMlYLAOQz82Vfj7G+XcfbCOIzbX75SlYTkBiSk/MTgDJzWGGN7qvEeLn09AoNTgMn2DJb47ILHsJV2wL6tA4biDuQUd3HlBK48MITvfgnB5NLP9rUrVUnYdBMJSQ1I3CyVNwrlGcL2ZLXVPjz3FItsSJw660XBNjfsJW4Optl++twwliIr+Oj8C5H2YvWMIttfsVKV+MQfES/hzPbEzcL2JLXmRsd9rdWM+S349LwP7q4Z9A3MssfWZvcM/nNxFJatnWKnM+UOOdvpkHjFSlXiE35Agg5ucdxBa3uIw11VD1lNWf86mzXlcsjwxbJqpdIZZXN1x6zUu49msKVWHBP6VlPi4r5DXPz3IOVku8V+G61tk3BVPMREcBFlVY94vanPOZwp18P1KzVDPSb0K9XdPYfiOs+alarEbbgBgser8DxrI/z+BQQZ1FXRsqbVNDhttVUrVX/JyJVKR0VRzcCalapsWHcdGzcKOCnPszTyc8U/tsCV324KiJrLtKsTTlr/spXazjJAxwR1An3R/cbvdj5en/BrhoGvYcP6KJxqnme+xZT/CrPtNsz2O1rgZJ9rtr9ipeZv70RBeRe/3wore/kBqZ/tpFzZ8IdvIeFxOuWy5onJP/G0yyEjlSexuv/WShU1d8dMOHk6092urH/tKiR8IylXa07wOEo8pT1Z3+cCnqyzfXXaCZ7KEk9bTX86C3g3shlcWff7/2H9a1cE/HVV+arAJSTpldOEk4Fbu1JF4MRikStVpl0/25V1v/sGq+GrlQs4G60xtsvxGguPKo+uVE25Dv5/ctkrSND6o90AAAAASUVORK5CYII=\" y=\"277.2969\"/><text fill=\"#3F51D4\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"83.3203\" x=\"118.8105\" y=\"322.1484\">database</text></g><!--entity CorporateWebApp.api--><g id=\"elem_CorporateWebApp.api\"><rect fill=\"#DDDDDD\" height=\"68.625\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#9A9A9A;stroke-width:0.5;\" width=\"50\" x=\"118.3105\" y=\"95.2969\"/><image height=\"30\" width=\"30\" x=\"128.3105\" xlink:href=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAYAAAA7MK6iAAAGZElEQVR4XpWXaUxUVxiGryjIvjOATdqIabQNdvnTNqnp8rdJ7Q9rWxXrUrcqKrggWFbBBcQFRWvSpGtsm9T+qG1NmybGLtFWSgVkV2BgYIABZmBwGAZmeHu+c+659w6QSic58edz3/d73+9DxXIwAj2HItkLhzU7HL054ej7IAz9uezlhWKgIBSDhfRCMFQUDEdxCBwlCzF8dCFGji/EaCm9IDwoC4LrZCBcpwLhPr0A7jML4KmYj4lz9AIweX4evBcD4Ls4D1MfzoNiORAJgndn0QdEwJpD8DANbssP4/CBghAMFjH4kWDYi9kHlARj5JiAO08ECfhJegRn4NOBGD8r4J6KAEycZ/DKAHgvCLjStT8KM+BcOcHDGTxUg0vl9iMhXPnw0WAMc3iQDi8L5PAxpnyMKZdwTbkKVzozo9C5L5LDuw8yy/3guu02sj1fVa7ChXIGPhasKpe2M9XlBCflZPt89gGqcgb3MrhiJnBmJKRyggvl4dz2vvx4DJQuYS8Fg2UpGDqZAvupFDhOs39LTRxOymezXcDlzAWcK2e2Kx17o2DOkHB6EX62j/56FpO2FkyYb4rXKd8t+Jw9sJdECOVkuxo4CXdpcBE2sp0rZ3ClfU80OjKiDfAo/gESTmD75fXoPWywnVseCk/LNTgvv6EFjs+cw9WZl6lhM9guZ6607Y4Bh+8leDSbN4Fl4CIZuIKDedqN8LwwOC69CO9QGwOHicCVSNvFzGXNdNtF2km9cj89Bm27ozV4B1cu4KTceaMCQ1+kqVWLmKY8DJPWGjgqn2UdF1XT0j7NdgkXVWPgeztjIOBG5WzuatrtVzJg/NG8Cd57mOChcHzyGrz9jeqCIbhMu141bclIeDmB34/Ff8G5ckPPvSNWDFSuMCgPZSGzYrA4VvTcANd7PlO50rojDhLelh47DS5nLnpO8P4zL8DT+RfveZ8KH/4qDRPd1eqSEcrlzB1kubZk9J4rLdvj0LojFq1S+S4GVuHte1TLSfmBGPQUpsCSFQXvg0H0lz3FF4xUjslx2AqjNbhYMnra/XrOAqc0b4uDhM+0PQa855nRGL5+Fr5JN1c++Fkaxmq/5apl2p1XM+Guu8LTLtcrV86PitxwOlxp2hoPHR7np1yzPSMGU54xePqaYbu0Et3ZCfCO2tB7dCl6VDjZPsVU9xdEi/Uqbefznlk1pfG9eBC8aWuc+gHS9lgNPvTDEThvfo6uvMfhtXfxtDu+y8Hob5V+J3X0eike/HFuTidVadicAII3bmHK2QeQciO8jdnuHR2AOetRtDPbPdYG9F9cCUt2MnwuO3oKHtPWa29BEnxj9jmdVKV+kwkEb+DwuBnKbV8fxGjVN9rMLceeg6e7jgfOeeMCHFdz/Ha76/ancP546KEnVbm7IQH1GxM4nNuuKudwNvOJoS505D4tbE9nSWdbztN/H9byl9B5KBlTXg+fuTypfcefhHfY8tCTqtRtMIHgDapyYbtQ3vPRFozWXtPTzuAdWYuZxQ7Rc6baVfc9bB+v9Tup7sZrsH9Jh0X9E4qUq3CZdqV2vQl17wp4/SZ68UL5VhPGrS0wF7+spf3+rlgM/VQOxy8V6pJh/c5dAh9LfNcBWjTipPZXrAB8PrFi+xq5cqoZXTVbvlCt1KYlMjC9BBXOlDO4uXwVXE2/c8ubad7U810JrFYuNu8EQ9WiMW6uQu+ZV2ecVEo6/WY7qUrNuiTUMHjtevEBdzeaUL/ZBHdXPcylr/OqNW8TabddycPIzct+VSO4pXA5fO6RGSeVwka/2U6qcmdtEu6sSzTATbiX+wrGzDWa7XLm8HnRmr5I77nhpE4O96LnxPN+J5WU02+2k6pUv8PA0+BjHTUszd1wtf4J1z3x3B3VcNb+rG84st6wXruKnmGhG8J4+y39ddxSwUJ9rwqn0CnVbydDwqXtDTufQNOe5Wjam4rmzFS07EtF6/5UNG1P1JeM4apJeGfuMrbdlsGSvxSWArZOi5aiu2Cx3vNsHa78/RYDG+D+tieyjpt42uWSET0XS+b/nlRSLf90VqpWL4IR/s8aXXltmn/V/JaMGrg5nVTDfxpoyViZcuX2m4tQtTrZD35nDSlPAlWNen6XLRmu3LDh+G6f40kl5fI/DdJ25faqRyDgUnmSplzYTqoTOZxXzah8TidVbDhj1WjD/QulY+96F742WQAAAABJRU5ErkJggg==\" y=\"105.2969\"/><text fill=\"#E2730E\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"27.7344\" x=\"129.4434\" y=\"150.1484\">api</text></g><!--link CorporateWebApp.api to CorporateWebApp.database--><g id=\"link_CorporateWebApp.api_CorporateWebApp.database\"><path d=\"M146.6705,164.3869 C149.6505,194.1869 153.184,229.5366 156.164,259.3166 \" fill=\"none\" id=\"CorporateWebApp.api-to-CorporateWebApp.database\" style=\"stroke:#707070;stroke-width:1;\"/><polygon fill=\"#707070\" points=\"156.9605,267.2769,159.1491,259.0179,153.1789,259.6153,156.9605,267.2769\" style=\"stroke:#707070;stroke-width:1;\"/><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"41.209\" x=\"154.3105\" y=\"206.4355\">Reads</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"195.5195\" y=\"206.4355\"> </text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"25.2305\" x=\"199.6973\" y=\"206.4355\">and</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"224.9277\" y=\"206.4355\"> </text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"42.1348\" x=\"229.1055\" y=\"206.4355\">writes</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"30.5215\" x=\"170.3008\" y=\"220.4043\">data</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"200.8223\" y=\"220.4043\"> </text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"50.25\" x=\"205\" y=\"220.4043\">from/to</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"56.3438\" x=\"184.6035\" y=\"234.373\">[http/api]</text></g><rect fill=\"none\" height=\"16.2969\" style=\"stroke:none;stroke-width:1;\" width=\"321.6211\" x=\"17\" y=\"376.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"57.9209\" x=\"17\" y=\"389.292\">Legend</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"79.7949\" y=\"389.292\"> </text><rect fill=\"none\" height=\"16.2969\" style=\"stroke:none;stroke-width:1;\" width=\"321.6211\" x=\"17\" y=\"392.5938\"/><text fill=\"#444444\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"7.7041\" x=\"21.4502\" y=\"405.5889\"/><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"29.1543\" y=\"405.5889\"> </text><text fill=\"#444444\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"121.7686\" x=\"38.0547\" y=\"405.5889\">system boundary</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"164.2734\" y=\"405.5889\"> </text><rect fill=\"#DDDDDD\" height=\"30\" style=\"stroke:none;stroke-width:1;\" width=\"321.6211\" x=\"17\" y=\"408.8906\"/><text fill=\"#9A9A9A\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"7.7041\" x=\"21.4502\" y=\"435.5889\"/><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"29.1543\" y=\"435.5889\"> </text><image height=\"30\" width=\"30\" x=\"33.6045\" xlink:href=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAYAAAA7MK6iAAAGZElEQVR4XpWXaUxUVxiGryjIvjOATdqIabQNdvnTNqnp8rdJ7Q9rWxXrUrcqKrggWFbBBcQFRWvSpGtsm9T+qG1NmybGLtFWSgVkV2BgYIABZmBwGAZmeHu+c+659w6QSic58edz3/d73+9DxXIwAj2HItkLhzU7HL054ej7IAz9uezlhWKgIBSDhfRCMFQUDEdxCBwlCzF8dCFGji/EaCm9IDwoC4LrZCBcpwLhPr0A7jML4KmYj4lz9AIweX4evBcD4Ls4D1MfzoNiORAJgndn0QdEwJpD8DANbssP4/CBghAMFjH4kWDYi9kHlARj5JiAO08ECfhJegRn4NOBGD8r4J6KAEycZ/DKAHgvCLjStT8KM+BcOcHDGTxUg0vl9iMhXPnw0WAMc3iQDi8L5PAxpnyMKZdwTbkKVzozo9C5L5LDuw8yy/3guu02sj1fVa7ChXIGPhasKpe2M9XlBCflZPt89gGqcgb3MrhiJnBmJKRyggvl4dz2vvx4DJQuYS8Fg2UpGDqZAvupFDhOs39LTRxOymezXcDlzAWcK2e2Kx17o2DOkHB6EX62j/56FpO2FkyYb4rXKd8t+Jw9sJdECOVkuxo4CXdpcBE2sp0rZ3ClfU80OjKiDfAo/gESTmD75fXoPWywnVseCk/LNTgvv6EFjs+cw9WZl6lhM9guZ6607Y4Bh+8leDSbN4Fl4CIZuIKDedqN8LwwOC69CO9QGwOHicCVSNvFzGXNdNtF2km9cj89Bm27ozV4B1cu4KTceaMCQ1+kqVWLmKY8DJPWGjgqn2UdF1XT0j7NdgkXVWPgeztjIOBG5WzuatrtVzJg/NG8Cd57mOChcHzyGrz9jeqCIbhMu141bclIeDmB34/Ff8G5ckPPvSNWDFSuMCgPZSGzYrA4VvTcANd7PlO50rojDhLelh47DS5nLnpO8P4zL8DT+RfveZ8KH/4qDRPd1eqSEcrlzB1kubZk9J4rLdvj0LojFq1S+S4GVuHte1TLSfmBGPQUpsCSFQXvg0H0lz3FF4xUjslx2AqjNbhYMnra/XrOAqc0b4uDhM+0PQa855nRGL5+Fr5JN1c++Fkaxmq/5apl2p1XM+Guu8LTLtcrV86PitxwOlxp2hoPHR7np1yzPSMGU54xePqaYbu0Et3ZCfCO2tB7dCl6VDjZPsVU9xdEi/Uqbefznlk1pfG9eBC8aWuc+gHS9lgNPvTDEThvfo6uvMfhtXfxtDu+y8Hob5V+J3X0eike/HFuTidVadicAII3bmHK2QeQciO8jdnuHR2AOetRtDPbPdYG9F9cCUt2MnwuO3oKHtPWa29BEnxj9jmdVKV+kwkEb+DwuBnKbV8fxGjVN9rMLceeg6e7jgfOeeMCHFdz/Ha76/ancP546KEnVbm7IQH1GxM4nNuuKudwNvOJoS505D4tbE9nSWdbztN/H9byl9B5KBlTXg+fuTypfcefhHfY8tCTqtRtMIHgDapyYbtQ3vPRFozWXtPTzuAdWYuZxQ7Rc6baVfc9bB+v9Tup7sZrsH9Jh0X9E4qUq3CZdqV2vQl17wp4/SZ68UL5VhPGrS0wF7+spf3+rlgM/VQOxy8V6pJh/c5dAh9LfNcBWjTipPZXrAB8PrFi+xq5cqoZXTVbvlCt1KYlMjC9BBXOlDO4uXwVXE2/c8ubad7U810JrFYuNu8EQ9WiMW6uQu+ZV2ecVEo6/WY7qUrNuiTUMHjtevEBdzeaUL/ZBHdXPcylr/OqNW8TabddycPIzct+VSO4pXA5fO6RGSeVwka/2U6qcmdtEu6sSzTATbiX+wrGzDWa7XLm8HnRmr5I77nhpE4O96LnxPN+J5WU02+2k6pUv8PA0+BjHTUszd1wtf4J1z3x3B3VcNb+rG84st6wXruKnmGhG8J4+y39ddxSwUJ9rwqn0CnVbydDwqXtDTufQNOe5Wjam4rmzFS07EtF6/5UNG1P1JeM4apJeGfuMrbdlsGSvxSWArZOi5aiu2Cx3vNsHa78/RYDG+D+tieyjpt42uWSET0XS+b/nlRSLf90VqpWL4IR/s8aXXltmn/V/JaMGrg5nVTDfxpoyViZcuX2m4tQtTrZD35nDSlPAlWNen6XLRmu3LDh+G6f40kl5fI/DdJ25faqRyDgUnmSplzYTqoTOZxXzah8TidVbDhj1WjD/QulY+96F742WQAAAABJRU5ErkJggg==\" y=\"408.8906\"/><text fill=\"#E2730E\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"226.1807\" x=\"72.5049\" y=\"435.5889\">Amazon Web Services - Lambda</text><text fill=\"#E2730E\" font-family=\"sans-serif\" font-size=\"10\" lengthAdjust=\"spacing\" textLength=\"31.0352\" x=\"303.1357\" y=\"436.5322\">(solid)</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"334.1709\" y=\"435.5889\"> </text><rect fill=\"#DDDDDD\" height=\"30\" style=\"stroke:none;stroke-width:1;\" width=\"321.6211\" x=\"17\" y=\"438.8906\"/><text fill=\"#9A9A9A\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"7.7041\" x=\"21.4502\" y=\"465.5889\"/><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"29.1543\" y=\"465.5889\"> </text><image height=\"30\" width=\"30\" x=\"33.6045\" xlink:href=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAYAAAA7MK6iAAAHDUlEQVR4Xn2Wi0+UVxrGv39nN9164SIgd4YZ5g4IbQUHuYiAl7rVXVmr7rpZdbNJ26ibmrY2u62xpqamXa3GXqStVFERFRjuwoDjCDgMDMN9YODZ857znW++AS3JSQgEfvM87/NelMwtXcgq7kHWGz3IfrMP2W89QU5JPwylHhhcg8jd/hTG8mcwVrBX6YOpehimnSPIq3kBc50flt0BWPaMw7p3Ata3J2H7Ywj2d6ZgPzANx59n4Tw4D2f9Apx/CSP/8BLyj0RQcHQZSmZhJwieWdTN4L0CvpXgAzBs8yC3bIjDc8u9Al71HKYdw8hjcHOtgJt3SXgQ1n0qfD8D/2mWwefgODgn4IcY/N0lFDC4kpHfgVg4U6+D5+jgBM5lz0TwaoKP6uBjHG4h5Srctn9Kg5NyR/088gnOlCvpznak57s1uLBdVU62lwrl3PYyoVwPJ9vNtQxcNxZrO8HfEcrtB2a47aRcwBcZ2N4GgmcUCOVZRV3YUv0ERTv7UVzrQfGuQQ4n5RIua87hZHuNVD7GlZceCsJ1JATX0RDK/kZgqvkMVy9rrqTZHiPN3irgTHlhZQ/oa2x8Ee6eOf5ytvarNR9k8CEYVOUUtmjNR7XANbvD6BxYQmBymf+vsr9OacrtZD2DK2nWR0iztQq4ox2FFT0MuoTJUAQ7Dg4K29+imvfrbI/W3PQK+O6TQYSmlzncdXSK2R6FU82VVPNDpFoI/hhke2FFF9q7ZrHjwACCkxFUM3j2mxIeTbtsNamcbM+rHuHwPcfHMTm1jL3/nERn/xK3XJ92giuppgcgeJoKd7o60PQgxG3fsb+fK7eX97281aRyzXYfivaNcqV7Toxz5Z39i9h2OBjbaky9kpJ7H6l5BG/RlEvb051u2Fw9urT3oLp+CJ9cDODqzRC+bQjh3KUJ1BwZial50b4RlnimXm01Le1vB2FjcPoAHJxibMZmDldtt0p4G097RkEn6o97EQ6voHdgHh9/4cffT42wN4qPL46j1xNGeHEF777vjx0yNdGayz4nuADn3IWAk/KWGOUlNd3wB8Jwbu9GYGIJD9qmYS3rQ25JHwwlT2As7YepzAPnziG0984jEIxg97FRTM0so+6YX6u5HDJSOQ0ZJTm7CRK+mZSzmmfaH+FWUxDPni+gfG8vb7UAS/rJMz4Meuf5hwhNRfij74d8YfzrIz8HU82rDg3DO7yI+21zsNbq+1zArQyuJGXegQY33OO2X70xhhs3A1rgyPIA62vjG6vHq0g79bm53CPAusBdaZhGw905nXKacGK2K0kZv0IPz7I0Y2o6wpVHbW/l4IXwMi5fC+DEaR/qT3jZe4YTZ4Zx+foE+90KB+v7nAJHtjt2qWHTbB+DsintFgT8NpKz7iDddA9z8xHk2B8weDOHk3KaZNatbvzjAy8+v/QC136cwPWbQZy/zD7Iv4fhrBrgYP1KNVc+xdzCCqzVvjUrVdmU+gsIvildwpvw/hkPenpnYHC0qIF7yMF1B/u0VqM+19u+54iX11v2uaVyEO4+1gFfTrx0pSqJKT8jCm/k8BRm+3unPZiZjeC/F3xIt7RwsH8szKbZEry+BXT2zvLnfc5+xoYMlYLAOQz82Vfj7G+XcfbCOIzbX75SlYTkBiSk/MTgDJzWGGN7qvEeLn09AoNTgMn2DJb47ILHsJV2wL6tA4biDuQUd3HlBK48MITvfgnB5NLP9rUrVUnYdBMJSQ1I3CyVNwrlGcL2ZLXVPjz3FItsSJw660XBNjfsJW4Optl++twwliIr+Oj8C5H2YvWMIttfsVKV+MQfES/hzPbEzcL2JLXmRsd9rdWM+S349LwP7q4Z9A3MssfWZvcM/nNxFJatnWKnM+UOOdvpkHjFSlXiE35Agg5ucdxBa3uIw11VD1lNWf86mzXlcsjwxbJqpdIZZXN1x6zUu49msKVWHBP6VlPi4r5DXPz3IOVku8V+G61tk3BVPMREcBFlVY94vanPOZwp18P1KzVDPSb0K9XdPYfiOs+alarEbbgBgser8DxrI/z+BQQZ1FXRsqbVNDhttVUrVX/JyJVKR0VRzcCalapsWHcdGzcKOCnPszTyc8U/tsCV324KiJrLtKsTTlr/spXazjJAxwR1An3R/cbvdj5en/BrhoGvYcP6KJxqnme+xZT/CrPtNsz2O1rgZJ9rtr9ipeZv70RBeRe/3wore/kBqZ/tpFzZ8IdvIeFxOuWy5onJP/G0yyEjlSexuv/WShU1d8dMOHk6092urH/tKiR8IylXa07wOEo8pT1Z3+cCnqyzfXXaCZ7KEk9bTX86C3g3shlcWff7/2H9a1cE/HVV+arAJSTpldOEk4Fbu1JF4MRikStVpl0/25V1v/sGq+GrlQs4G60xtsvxGguPKo+uVE25Dv5/ctkrSND6o90AAAAASUVORK5CYII=\" y=\"438.8906\"/><text fill=\"#3F51D4\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"199.2061\" x=\"72.5049\" y=\"465.5889\">Amazon Web Services - RDS</text><text fill=\"#3F51D4\" font-family=\"sans-serif\" font-size=\"10\" lengthAdjust=\"spacing\" textLength=\"31.0352\" x=\"276.1611\" y=\"466.5322\">(solid)</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"307.1963\" y=\"465.5889\"> </text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"8.4287\" x=\"21.4502\" y=\"481.8857\">─</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"29.8789\" y=\"481.8857\"> </text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"86.5703\" x=\"38.7793\" y=\"481.8857\">Relationship</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"129.7998\" y=\"481.8857\"> </text><line style=\"stroke:none;stroke-width:1;\" x1=\"17\" x2=\"338.6211\" y1=\"376.2969\" y2=\"376.2969\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"17\" x2=\"338.6211\" y1=\"392.5938\" y2=\"392.5938\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"17\" x2=\"338.6211\" y1=\"408.8906\" y2=\"408.8906\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"17\" x2=\"338.6211\" y1=\"438.8906\" y2=\"438.8906\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"17\" x2=\"338.6211\" y1=\"468.8906\" y2=\"468.8906\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"17\" x2=\"338.6211\" y1=\"485.1875\" y2=\"485.1875\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"17\" x2=\"17\" y1=\"376.2969\" y2=\"485.1875\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"338.6211\" x2=\"338.6211\" y1=\"376.2969\" y2=\"485.1875\"/><!--SRC=[jLDTQzim57tNhz2qFIImsFdgqfMvaALXUoWhn8Cy6jcwiSLioKWtozBI_px9paV9GXWhiy0sHz8zvvvxhmMa5cfkE6f3bLP0K689TAPDhHqAT0afdTOrxJbC8PSAZ2K4TKrHqrGZweeAQI13gHKXRwJAohK0-cas3cVZsrCWyL7W5vxVQCBV4Z8LObv21Gg_yxp3fXL_rAgH4eFvAJEmJiyzhrB1sNlwBirdkjGcOcz5ypIODWBC7l_8_VBuoj7iKHXEHdtmgAsDH8YOhFAR0h6sDs5eaQFC0ejcdU7Qo4SJPBeAiN32RCWRJRqDf3sxqzGRzeUZe3y8HeDmQh8YcIxZNgio6Ly7jSgVRCPBYFh1-CFrvEgvOIwuq1kfyeWTPSUuTSUOrQKKhFjtTYpkujTuCLfT3SJuFthHdd4gN-U5DsC1PME4-tBVThQGjR_W6skVpwJlbqTBrrJdqIOqZIZpSKcyjGXLybclbU1css678N1Ekn58qjsEkyx-6926d-SsOhjIiIvz8lGuDPsJS87Wo5DkmKNR_xP9P8Lg3H1WCzF-jg4lLjvbz2FogLmYvRLqVExzRrJ7cJkmFHFYwd2Uw4BA2-32Kgu4tVXsizJlqPNnNQLVYFCT6ExrDifEgtvGGkAl3ylaVlvb_kskupeLkhy1]--></g></svg>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.SVG object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "from IPython.display import SVG, display, HTML\n",
     "\n",
@@ -199,9 +392,250 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/json": {
+       "configuration": {
+        "scope": "SoftwareSystem"
+       },
+       "description": "",
+       "documentation": {},
+       "id": 3,
+       "model": {
+        "deploymentNodes": [],
+        "people": [
+         {
+          "description": "",
+          "group": "My Company",
+          "id": "19",
+          "location": "Unspecified",
+          "name": "Web Application User",
+          "properties": {},
+          "relationships": [
+           {
+            "description": "Reads and writes email using",
+            "destinationId": "24",
+            "id": "25",
+            "sourceId": "19",
+            "tags": "Relationship"
+           },
+           {
+            "description": "Create work order using",
+            "destinationId": "20",
+            "id": "26",
+            "sourceId": "19",
+            "tags": "Relationship"
+           }
+          ],
+          "tags": "Amazon Web Services - User,Person,Element"
+         }
+        ],
+        "properties": {
+         "structurizr.groupSeparator": "/"
+        },
+        "softwareSystems": [
+         {
+          "containers": [
+           {
+            "components": [],
+            "description": "",
+            "group": "My Company",
+            "id": "21",
+            "name": "database",
+            "properties": {},
+            "relationships": [],
+            "tags": "Container,Amazon Web Services - RDS,Element",
+            "technology": ""
+           },
+           {
+            "components": [],
+            "description": "",
+            "group": "My Company",
+            "id": "22",
+            "name": "api",
+            "properties": {},
+            "relationships": [
+             {
+              "description": "Reads and writes data from/to",
+              "destinationId": "21",
+              "id": "23",
+              "sourceId": "22",
+              "tags": "Relationship",
+              "technology": "http/api"
+             }
+            ],
+            "tags": "Amazon Web Services - Lambda,Container,Element",
+            "technology": ""
+           }
+          ],
+          "description": "",
+          "documentation": {},
+          "group": "My Company",
+          "id": "20",
+          "location": "Unspecified",
+          "name": "Corporate Web App",
+          "properties": {},
+          "relationships": [
+           {
+            "description": "sends notification using",
+            "destinationId": "24",
+            "id": "27",
+            "sourceId": "20",
+            "tags": "Relationship",
+            "technology": ""
+           }
+          ],
+          "tags": "Software System,Element"
+         },
+         {
+          "containers": [],
+          "description": "",
+          "documentation": {},
+          "group": "Microsoft",
+          "id": "24",
+          "location": "Unspecified",
+          "name": "Microsoft 365",
+          "properties": {},
+          "relationships": [],
+          "tags": "Software System,Element"
+         }
+        ]
+       },
+       "name": "w",
+       "views": {
+        "configuration": {
+         "branding": {},
+         "properties": {
+          "c4plantuml.tags": "true"
+         },
+         "styles": {
+          "elements": [
+           {
+            "color": "#242f3e",
+            "icon": "https://static.structurizr.com/themes/amazon-web-services-2023.01.31/Res_User_48_Light.png",
+            "stroke": "#242f3e",
+            "tag": "Amazon Web Services - User"
+           },
+           {
+            "color": "#e2730e",
+            "icon": "https://static.structurizr.com/themes/amazon-web-services-2023.01.31/Arch_AWS-Lambda_48.png",
+            "stroke": "#e2730e",
+            "tag": "Amazon Web Services - Lambda"
+           },
+           {
+            "color": "#3f51d4",
+            "icon": "https://static.structurizr.com/themes/amazon-web-services-2023.01.31/Arch_Amazon-RDS_48.png",
+            "stroke": "#3f51d4",
+            "tag": "Amazon Web Services - RDS"
+           }
+          ]
+         },
+         "terminology": {}
+        },
+        "containerViews": [
+         {
+          "automaticLayout": {
+           "edgeSeparation": 0,
+           "implementation": "Graphviz",
+           "nodeSeparation": 300,
+           "rankDirection": "LeftRight",
+           "rankSeparation": 300,
+           "vertices": false
+          },
+          "description": "Web App Container View",
+          "elements": [
+           {
+            "id": "21",
+            "x": 0,
+            "y": 0
+           },
+           {
+            "id": "22",
+            "x": 0,
+            "y": 0
+           }
+          ],
+          "key": "web_app_container_view_00",
+          "relationships": [
+           {
+            "id": "23"
+           }
+          ],
+          "softwareSystemId": "20"
+         }
+        ],
+        "systemContextViews": [
+         {
+          "automaticLayout": {
+           "applied": false,
+           "edgeSeparation": 0,
+           "implementation": "Graphviz",
+           "nodeSeparation": 300,
+           "rankDirection": "LeftRight",
+           "rankSeparation": 300,
+           "vertices": false
+          },
+          "description": "Web App System Context",
+          "elements": [
+           {
+            "id": "19",
+            "x": 0,
+            "y": 0
+           },
+           {
+            "id": "20",
+            "x": 0,
+            "y": 0
+           },
+           {
+            "id": "24",
+            "x": 0,
+            "y": 0
+           }
+          ],
+          "enterpriseBoundaryVisible": true,
+          "key": "web_app_system_context_00",
+          "order": 1,
+          "relationships": [
+           {
+            "id": "26"
+           },
+           {
+            "id": "27"
+           }
+          ],
+          "softwareSystemId": "20"
+         }
+        ]
+       }
+      },
+      "text/html": [
+       "<div style=\"margin-bottom: 2em;\">\n",
+       "<h3 style=\"font-family: sans-serif; color: #333;\">web_app_system_context_00</h3>\n",
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" contentStyleType=\"text/css\" height=\"498px\" preserveAspectRatio=\"none\" style=\"width:399px;height:498px;background:#FFFFFF;\" version=\"1.1\" viewBox=\"0 0 399 498\" width=\"399px\" zoomAndPan=\"magnify\"><title>Corporate Web App - System Context</title><defs/><g><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"295.0801\" x=\"45.1748\" y=\"22.9951\">Corporate Web App - System Context</text><!--entity WebApplicationUser--><g id=\"elem_WebApplicationUser\"><rect fill=\"#DDDDDD\" height=\"68.625\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#9A9A9A;stroke-width:0.5;\" width=\"214.4063\" x=\"83.5\" y=\"44.2969\"/><image height=\"30\" width=\"30\" x=\"175.7031\" xlink:href=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAYAAAA7MK6iAAADU0lEQVR4XtWW3UtTcRjHt7M39+KcO8dtZ247Z9vZcZt7OXvR5tIdF0aIlAgF1WV4YRBRgSB0E9lN4k1/g3kVZHeBRhR0VzfRTRfdFoSiYpGKQT3PKKFHD+7Fgj7wwOF8v8/znN/2e9Pp/hekdHkg3FtaDCdL72oBz1KmXKa+Y4MXk4OxrPoypqifIR7JxZE5DHyuvQONDycHaV4L6HWBSHo0plR20idGnrg8IZY68B1oS+gJRjKjOr1eTz0NE0+c9ErZysdgLD8XlSQT1X+DWkDOzaEXc6jeEFarVScp6iL8lM9FUWSoThEEgUEvNH9os9maHzXHiyEosut0e09TTQv0Yk6XPxyiWt24fcJZKLJp72BFqmmBXsxhfeI5qtUNNL4CRdYcTs5NNS0cTtYNOauYS7W6cXuFS1Bk3e5keappgV7MgRFfplrduL1iAYpsB0Wpj2paoBdzWJ9QoFrdMIwBZmnldU9BvU81LeLgxRzGYDBQrSE4v9QPhdbCysAYYzRSeR/U0INezKF6wxiNZr2cHZrHSSYXhgfMZsuBTcRssZhQq3mylXnMoZ6maHO0mxPF6jQU3koVqyt8JDXlj6TLGPic6ju1jFq8UJ1GL81vCXsH1x1Nl2/BYbAHTX6Q2ItkBqftTi5I85rGYDSbxNQA7sEbEN8hnsH/eLtHqV6Qlep4TBm+LimVp9gcPXBMPoCc1kYdkvNnoNh7GOXbSKZ/iuUFzfXs8Ue4RKZ/EvbqN+D/EIwp49RzJHo9w0RT5Yswkm9STl2wt7MW6tHC5nRbYzl1CT54B2tAqSMPl32EeGECErd9QuKajePqT/yFo7PTeHPm7g1sDrXOU/1QgsmUBCNdTRXVWao1Sjyr4txYD/bkE1T7A1h/JikztCzn1Bc2m6O1CQK0WR3WWLbyKpodWjGYzAfW/z6eQKQXjBtBWSlRrVn8kpKHUW92+aNZqtXArRVm42OYlYtUaxW4xSxA3aVDt29Pt8jBl+2yvNj4MjgC1h8ew8nq7Q77qAaHvjgC4hacpzLVWgVrYm04Kg9eoeDGMAniGlxdOKq1it3FunClQOOrVMPGeAh85cXEPXi+c5wB+8Es1P4Cv+oM7atzdQUmxGTp09+MTk9ggvb95/wEFH7u7EgAMNMAAAAASUVORK5CYII=\" y=\"54.2969\"/><text fill=\"#242F3E\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"39.9531\" x=\"93.5\" y=\"99.1484\">Web</text><text fill=\"#242F3E\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"5.5703\" x=\"133.4531\" y=\"99.1484\">&#160;</text><text fill=\"#242F3E\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"102.0547\" x=\"139.0234\" y=\"99.1484\">Application</text><text fill=\"#242F3E\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"5.5703\" x=\"241.0781\" y=\"99.1484\">&#160;</text><text fill=\"#242F3E\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"41.2578\" x=\"246.6484\" y=\"99.1484\">User</text></g><!--entity CorporateWebApp--><g id=\"elem_CorporateWebApp\"><rect fill=\"#1168BD\" height=\"38.625\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#3C7FC0;stroke-width:0.5;\" width=\"196.6406\" x=\"7\" y=\"202.2969\"/><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"90.2578\" x=\"17\" y=\"227.1484\">Corporate</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"5.5703\" x=\"107.2578\" y=\"227.1484\">&#160;</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"39.9531\" x=\"112.8281\" y=\"227.1484\">Web</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"5.5703\" x=\"152.7813\" y=\"227.1484\">&#160;</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"35.2891\" x=\"158.3516\" y=\"227.1484\">App</text></g><!--entity Microsoft365--><g id=\"elem_Microsoft365\"><rect fill=\"#1168BD\" height=\"38.625\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#3C7FC0;stroke-width:0.5;\" width=\"143.8672\" x=\"118.5\" y=\"330.2969\"/><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"84.8984\" x=\"128.5\" y=\"355.1484\">Microsoft</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"5.5703\" x=\"213.3984\" y=\"355.1484\">&#160;</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"33.3984\" x=\"218.9688\" y=\"355.1484\">365</text></g><!--link WebApplicationUser to Microsoft365--><g id=\"link_WebApplicationUser_Microsoft365\"><path d=\"M232.48,113.4069 C240.63,122.1869 248.03,132.3069 252.5,143.2969 C278.82,207.9169 283.07,237.5669 252.5,300.2969 C246.57,312.4569 242.4719,317.8198 231.6819,325.5198 \" fill=\"none\" id=\"WebApplicationUser-to-Microsoft365\" style=\"stroke:#707070;stroke-width:1;\"/><polygon fill=\"#707070\" points=\"225.17,330.1669,233.4246,327.9618,229.9393,323.0779,225.17,330.1669\" style=\"stroke:#707070;stroke-width:1;\"/><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"41.209\" x=\"274.5\" y=\"219.4355\">Reads</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"315.709\" y=\"219.4355\">&#160;</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"25.2305\" x=\"319.8867\" y=\"219.4355\">and</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"345.1172\" y=\"219.4355\">&#160;</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"42.1348\" x=\"349.2949\" y=\"219.4355\">writes</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"36.9668\" x=\"293.9268\" y=\"233.4043\">email</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"330.8936\" y=\"233.4043\">&#160;</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"36.9316\" x=\"335.0713\" y=\"233.4043\">using</text></g><!--link WebApplicationUser to CorporateWebApp--><g id=\"link_WebApplicationUser_CorporateWebApp\"><path d=\"M147.38,113.4769 C138.36,122.3169 129.71,132.4469 123.5,143.2969 C113,161.6369 109.5013,177.7856 107.6813,194.2056 \" fill=\"none\" id=\"WebApplicationUser-to-CorporateWebApp\" style=\"stroke:#707070;stroke-width:1;\"/><polygon fill=\"#707070\" points=\"106.8,202.1569,110.6631,194.5361,104.6996,193.8751,106.8,202.1569\" style=\"stroke:#707070;stroke-width:1;\"/><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"44.8359\" x=\"124.5\" y=\"155.4355\">Create</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"169.3359\" y=\"155.4355\">&#160;</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"33.2285\" x=\"173.5137\" y=\"155.4355\">work</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"206.7422\" y=\"155.4355\">&#160;</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"36.8086\" x=\"210.9199\" y=\"155.4355\">order</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"36.9316\" x=\"167.6484\" y=\"169.4043\">using</text></g><!--link CorporateWebApp to Microsoft365--><g id=\"link_CorporateWebApp_Microsoft365\"><path d=\"M106.82,241.4369 C108.76,258.0969 113.57,282.5269 125.5,300.2969 C133.5,312.2169 138.8508,317.8247 150.3208,325.6847 \" fill=\"none\" id=\"CorporateWebApp-to-Microsoft365\" style=\"stroke:#707070;stroke-width:1;\"/><polygon fill=\"#707070\" points=\"156.92,330.2069,152.0166,323.21,148.625,328.1594,156.92,330.2069\" style=\"stroke:#707070;stroke-width:1;\"/><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"39.5566\" x=\"126.5\" y=\"283.4355\">sends</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"166.0566\" y=\"283.4355\">&#160;</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"77.8184\" x=\"170.2344\" y=\"283.4355\">notification</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"36.9316\" x=\"168.8105\" y=\"297.4043\">using</text></g><rect fill=\"none\" height=\"16.2969\" style=\"stroke:none;stroke-width:1;\" width=\"297.1621\" x=\"71.2676\" y=\"392.9219\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"57.9209\" x=\"71.2676\" y=\"405.917\">Legend</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"134.0625\" y=\"405.917\">&#160;</text><rect fill=\"#1168BD\" height=\"16.2969\" style=\"stroke:none;stroke-width:1;\" width=\"297.1621\" x=\"71.2676\" y=\"409.2188\"/><text fill=\"#3C7FC0\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"7.7041\" x=\"75.7178\" y=\"422.2139\"></text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"83.4219\" y=\"422.2139\">&#160;</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"50.6133\" x=\"92.3223\" y=\"422.2139\">system</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"147.3857\" y=\"422.2139\">&#160;</text><rect fill=\"#DDDDDD\" height=\"30\" style=\"stroke:none;stroke-width:1;\" width=\"297.1621\" x=\"71.2676\" y=\"425.5156\"/><text fill=\"#9A9A9A\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"7.7041\" x=\"75.7178\" y=\"452.2139\"></text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"83.4219\" y=\"452.2139\">&#160;</text><image height=\"30\" width=\"30\" x=\"87.8721\" xlink:href=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAYAAAA7MK6iAAADU0lEQVR4XtWW3UtTcRjHt7M39+KcO8dtZ247Z9vZcZt7OXvR5tIdF0aIlAgF1WV4YRBRgSB0E9lN4k1/g3kVZHeBRhR0VzfRTRfdFoSiYpGKQT3PKKFHD+7Fgj7wwOF8v8/znN/2e9Pp/hekdHkg3FtaDCdL72oBz1KmXKa+Y4MXk4OxrPoypqifIR7JxZE5DHyuvQONDycHaV4L6HWBSHo0plR20idGnrg8IZY68B1oS+gJRjKjOr1eTz0NE0+c9ErZysdgLD8XlSQT1X+DWkDOzaEXc6jeEFarVScp6iL8lM9FUWSoThEEgUEvNH9os9maHzXHiyEosut0e09TTQv0Yk6XPxyiWt24fcJZKLJp72BFqmmBXsxhfeI5qtUNNL4CRdYcTs5NNS0cTtYNOauYS7W6cXuFS1Bk3e5keappgV7MgRFfplrduL1iAYpsB0Wpj2paoBdzWJ9QoFrdMIwBZmnldU9BvU81LeLgxRzGYDBQrSE4v9QPhdbCysAYYzRSeR/U0INezKF6wxiNZr2cHZrHSSYXhgfMZsuBTcRssZhQq3mylXnMoZ6maHO0mxPF6jQU3koVqyt8JDXlj6TLGPic6ju1jFq8UJ1GL81vCXsH1x1Nl2/BYbAHTX6Q2ItkBqftTi5I85rGYDSbxNQA7sEbEN8hnsH/eLtHqV6Qlep4TBm+LimVp9gcPXBMPoCc1kYdkvNnoNh7GOXbSKZ/iuUFzfXs8Ue4RKZ/EvbqN+D/EIwp49RzJHo9w0RT5Yswkm9STl2wt7MW6tHC5nRbYzl1CT54B2tAqSMPl32EeGECErd9QuKajePqT/yFo7PTeHPm7g1sDrXOU/1QgsmUBCNdTRXVWao1Sjyr4txYD/bkE1T7A1h/JikztCzn1Bc2m6O1CQK0WR3WWLbyKpodWjGYzAfW/z6eQKQXjBtBWSlRrVn8kpKHUW92+aNZqtXArRVm42OYlYtUaxW4xSxA3aVDt29Pt8jBl+2yvNj4MjgC1h8ew8nq7Q77qAaHvjgC4hacpzLVWgVrYm04Kg9eoeDGMAniGlxdOKq1it3FunClQOOrVMPGeAh85cXEPXi+c5wB+8Es1P4Cv+oM7atzdQUmxGTp09+MTk9ggvb95/wEFH7u7EgAMNMAAAAASUVORK5CYII=\" y=\"425.5156\"/><text fill=\"#242F3E\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"201.7217\" x=\"126.7725\" y=\"452.2139\">Amazon Web Services - User</text><text fill=\"#242F3E\" font-family=\"sans-serif\" font-size=\"10\" lengthAdjust=\"spacing\" textLength=\"31.0352\" x=\"332.9443\" y=\"453.1572\">(solid)</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"363.9795\" y=\"452.2139\">&#160;</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"8.4287\" x=\"75.7178\" y=\"468.5107\">&#9472;</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"84.1465\" y=\"468.5107\">&#160;</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"86.5703\" x=\"93.0469\" y=\"468.5107\">Relationship</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"184.0674\" y=\"468.5107\">&#160;</text><line style=\"stroke:none;stroke-width:1;\" x1=\"71.2676\" x2=\"368.4297\" y1=\"392.9219\" y2=\"392.9219\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"71.2676\" x2=\"368.4297\" y1=\"409.2188\" y2=\"409.2188\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"71.2676\" x2=\"368.4297\" y1=\"425.5156\" y2=\"425.5156\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"71.2676\" x2=\"368.4297\" y1=\"455.5156\" y2=\"455.5156\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"71.2676\" x2=\"368.4297\" y1=\"471.8125\" y2=\"471.8125\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"71.2676\" x2=\"71.2676\" y1=\"392.9219\" y2=\"471.8125\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"368.4297\" x2=\"368.4297\" y1=\"392.9219\" y2=\"471.8125\"/><!--SRC=[dLDTRzCm57tFhxW47ZffJRgs6p2HILMfu643r8Bs6BdsRM8jiIFVMyg6-E-pqmzG5mHQ_13v93dd-9mRGWR2HZZ1re6n1YFMN25ChMkiHn5kSGcJfe4-BEw9iVQF3ECFZYAs3R25fMMsDIZjKBAs9efUQ2EhjK9uDnsdq_7LCP3lAAwYQABKhC8Q3NyLHI-UrEB1cbPpWUwxbaXU-1kXYq_XrRAOsigwB7wfsgl5h5FezlXR4LR0LrvYZmx7mzK80qgDqunPhElYicHkw39DYGLhcH2xjUIrqmykaRPEkVIsA1Mje_u6bttQEUeF1yDHCZXBHcVf72aFzlBnc_nQ5oKdZIb-aXGLPeFaOdZ-gvKjXR8RROei_krvmVV-fPXifLLyqaOnnwgDmTz5Y99AtOGFGbZxmxmUX1NGIXliHbjgo20El5_GaJKzdwcliTAoPGwUJo7UbRj73qah9EcsPbaKbFsZ6AzvbmMnxOZq3jEp5VL2J-QfKsKt2bsKDrewItR5eujpptVOWj__DrVaW-qCueXzZa8H2ADW4-Q506kXArYJht3RXopDdsB7XHqK_oROaP334C_6kZjev-EvSa-eZmv7QFpXZ6MzsjV-3ALeyV7pRNuz-p3xzBxdVnqyUGG0]--></g></svg>\n",
+       "</div>\n",
+       "<div style=\"margin-bottom: 2em;\">\n",
+       "<h3 style=\"font-family: sans-serif; color: #333;\">web_app_container_view_00</h3>\n",
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" contentStyleType=\"text/css\" height=\"512px\" preserveAspectRatio=\"none\" style=\"width:363px;height:512px;background:#FFFFFF;\" version=\"1.1\" viewBox=\"0 0 363 512\" width=\"363px\" zoomAndPan=\"magnify\"><title>Corporate Web App - Containers</title><defs/><g><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"255.6162\" x=\"50.0024\" y=\"22.9951\">Corporate Web App - Containers</text><!--cluster CorporateWebApp_boundary--><g id=\"cluster_CorporateWebApp_boundary\"><rect fill=\"none\" height=\"308\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#444444;stroke-width:1;stroke-dasharray:7.0,7.0;\" width=\"192\" x=\"89.3105\" y=\"44.2969\"/><text fill=\"#444444\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"176.6406\" x=\"96.9902\" y=\"61.1484\">Corporate Web App</text><text fill=\"#444444\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"59.4551\" x=\"155.583\" y=\"76.0605\">[system]</text></g><!--entity CorporateWebApp.database--><g id=\"elem_CorporateWebApp.database\"><rect fill=\"#DDDDDD\" height=\"68.625\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#9A9A9A;stroke-width:0.5;\" width=\"103.3203\" x=\"108.8105\" y=\"267.2969\"/><image height=\"30\" width=\"30\" x=\"145.4707\" xlink:href=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAYAAAA7MK6iAAAHDUlEQVR4Xn2Wi0+UVxrGv39nN9164SIgd4YZ5g4IbQUHuYiAl7rVXVmr7rpZdbNJ26ibmrY2u62xpqamXa3GXqStVFERFRjuwoDjCDgMDMN9YODZ857znW++AS3JSQgEfvM87/NelMwtXcgq7kHWGz3IfrMP2W89QU5JPwylHhhcg8jd/hTG8mcwVrBX6YOpehimnSPIq3kBc50flt0BWPaMw7p3Ata3J2H7Ywj2d6ZgPzANx59n4Tw4D2f9Apx/CSP/8BLyj0RQcHQZSmZhJwieWdTN4L0CvpXgAzBs8yC3bIjDc8u9Al71HKYdw8hjcHOtgJt3SXgQ1n0qfD8D/2mWwefgODgn4IcY/N0lFDC4kpHfgVg4U6+D5+jgBM5lz0TwaoKP6uBjHG4h5Srctn9Kg5NyR/088gnOlCvpznak57s1uLBdVU62lwrl3PYyoVwPJ9vNtQxcNxZrO8HfEcrtB2a47aRcwBcZ2N4GgmcUCOVZRV3YUv0ERTv7UVzrQfGuQQ4n5RIua87hZHuNVD7GlZceCsJ1JATX0RDK/kZgqvkMVy9rrqTZHiPN3irgTHlhZQ/oa2x8Ee6eOf5ytvarNR9k8CEYVOUUtmjNR7XANbvD6BxYQmBymf+vsr9OacrtZD2DK2nWR0iztQq4ox2FFT0MuoTJUAQ7Dg4K29+imvfrbI/W3PQK+O6TQYSmlzncdXSK2R6FU82VVPNDpFoI/hhke2FFF9q7ZrHjwACCkxFUM3j2mxIeTbtsNamcbM+rHuHwPcfHMTm1jL3/nERn/xK3XJ92giuppgcgeJoKd7o60PQgxG3fsb+fK7eX97281aRyzXYfivaNcqV7Toxz5Z39i9h2OBjbaky9kpJ7H6l5BG/RlEvb051u2Fw9urT3oLp+CJ9cDODqzRC+bQjh3KUJ1BwZial50b4RlnimXm01Le1vB2FjcPoAHJxibMZmDldtt0p4G097RkEn6o97EQ6voHdgHh9/4cffT42wN4qPL46j1xNGeHEF777vjx0yNdGayz4nuADn3IWAk/KWGOUlNd3wB8Jwbu9GYGIJD9qmYS3rQ25JHwwlT2As7YepzAPnziG0984jEIxg97FRTM0so+6YX6u5HDJSOQ0ZJTm7CRK+mZSzmmfaH+FWUxDPni+gfG8vb7UAS/rJMz4Meuf5hwhNRfij74d8YfzrIz8HU82rDg3DO7yI+21zsNbq+1zArQyuJGXegQY33OO2X70xhhs3A1rgyPIA62vjG6vHq0g79bm53CPAusBdaZhGw905nXKacGK2K0kZv0IPz7I0Y2o6wpVHbW/l4IXwMi5fC+DEaR/qT3jZe4YTZ4Zx+foE+90KB+v7nAJHtjt2qWHTbB+DsintFgT8NpKz7iDddA9z8xHk2B8weDOHk3KaZNatbvzjAy8+v/QC136cwPWbQZy/zD7Iv4fhrBrgYP1KNVc+xdzCCqzVvjUrVdmU+gsIvildwpvw/hkPenpnYHC0qIF7yMF1B/u0VqM+19u+54iX11v2uaVyEO4+1gFfTrx0pSqJKT8jCm/k8BRm+3unPZiZjeC/F3xIt7RwsH8szKbZEry+BXT2zvLnfc5+xoYMlYLAOQz82Vfj7G+XcfbCOIzbX75SlYTkBiSk/MTgDJzWGGN7qvEeLn09AoNTgMn2DJb47ILHsJV2wL6tA4biDuQUd3HlBK48MITvfgnB5NLP9rUrVUnYdBMJSQ1I3CyVNwrlGcL2ZLXVPjz3FItsSJw660XBNjfsJW4Optl++twwliIr+Oj8C5H2YvWMIttfsVKV+MQfES/hzPbEzcL2JLXmRsd9rdWM+S349LwP7q4Z9A3MssfWZvcM/nNxFJatnWKnM+UOOdvpkHjFSlXiE35Agg5ucdxBa3uIw11VD1lNWf86mzXlcsjwxbJqpdIZZXN1x6zUu49msKVWHBP6VlPi4r5DXPz3IOVku8V+G61tk3BVPMREcBFlVY94vanPOZwp18P1KzVDPSb0K9XdPYfiOs+alarEbbgBgser8DxrI/z+BQQZ1FXRsqbVNDhttVUrVX/JyJVKR0VRzcCalapsWHcdGzcKOCnPszTyc8U/tsCV324KiJrLtKsTTlr/spXazjJAxwR1An3R/cbvdj5en/BrhoGvYcP6KJxqnme+xZT/CrPtNsz2O1rgZJ9rtr9ipeZv70RBeRe/3wore/kBqZ/tpFzZ8IdvIeFxOuWy5onJP/G0yyEjlSexuv/WShU1d8dMOHk6092urH/tKiR8IylXa07wOEo8pT1Z3+cCnqyzfXXaCZ7KEk9bTX86C3g3shlcWff7/2H9a1cE/HVV+arAJSTpldOEk4Fbu1JF4MRikStVpl0/25V1v/sGq+GrlQs4G60xtsvxGguPKo+uVE25Dv5/ctkrSND6o90AAAAASUVORK5CYII=\" y=\"277.2969\"/><text fill=\"#3F51D4\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"83.3203\" x=\"118.8105\" y=\"322.1484\">database</text></g><!--entity CorporateWebApp.api--><g id=\"elem_CorporateWebApp.api\"><rect fill=\"#DDDDDD\" height=\"68.625\" rx=\"2.5\" ry=\"2.5\" style=\"stroke:#9A9A9A;stroke-width:0.5;\" width=\"50\" x=\"118.3105\" y=\"95.2969\"/><image height=\"30\" width=\"30\" x=\"128.3105\" xlink:href=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAYAAAA7MK6iAAAGZElEQVR4XpWXaUxUVxiGryjIvjOATdqIabQNdvnTNqnp8rdJ7Q9rWxXrUrcqKrggWFbBBcQFRWvSpGtsm9T+qG1NmybGLtFWSgVkV2BgYIABZmBwGAZmeHu+c+659w6QSic58edz3/d73+9DxXIwAj2HItkLhzU7HL054ej7IAz9uezlhWKgIBSDhfRCMFQUDEdxCBwlCzF8dCFGji/EaCm9IDwoC4LrZCBcpwLhPr0A7jML4KmYj4lz9AIweX4evBcD4Ls4D1MfzoNiORAJgndn0QdEwJpD8DANbssP4/CBghAMFjH4kWDYi9kHlARj5JiAO08ECfhJegRn4NOBGD8r4J6KAEycZ/DKAHgvCLjStT8KM+BcOcHDGTxUg0vl9iMhXPnw0WAMc3iQDi8L5PAxpnyMKZdwTbkKVzozo9C5L5LDuw8yy/3guu02sj1fVa7ChXIGPhasKpe2M9XlBCflZPt89gGqcgb3MrhiJnBmJKRyggvl4dz2vvx4DJQuYS8Fg2UpGDqZAvupFDhOs39LTRxOymezXcDlzAWcK2e2Kx17o2DOkHB6EX62j/56FpO2FkyYb4rXKd8t+Jw9sJdECOVkuxo4CXdpcBE2sp0rZ3ClfU80OjKiDfAo/gESTmD75fXoPWywnVseCk/LNTgvv6EFjs+cw9WZl6lhM9guZ6607Y4Bh+8leDSbN4Fl4CIZuIKDedqN8LwwOC69CO9QGwOHicCVSNvFzGXNdNtF2km9cj89Bm27ozV4B1cu4KTceaMCQ1+kqVWLmKY8DJPWGjgqn2UdF1XT0j7NdgkXVWPgeztjIOBG5WzuatrtVzJg/NG8Cd57mOChcHzyGrz9jeqCIbhMu141bclIeDmB34/Ff8G5ckPPvSNWDFSuMCgPZSGzYrA4VvTcANd7PlO50rojDhLelh47DS5nLnpO8P4zL8DT+RfveZ8KH/4qDRPd1eqSEcrlzB1kubZk9J4rLdvj0LojFq1S+S4GVuHte1TLSfmBGPQUpsCSFQXvg0H0lz3FF4xUjslx2AqjNbhYMnra/XrOAqc0b4uDhM+0PQa855nRGL5+Fr5JN1c++Fkaxmq/5apl2p1XM+Guu8LTLtcrV86PitxwOlxp2hoPHR7np1yzPSMGU54xePqaYbu0Et3ZCfCO2tB7dCl6VDjZPsVU9xdEi/Uqbefznlk1pfG9eBC8aWuc+gHS9lgNPvTDEThvfo6uvMfhtXfxtDu+y8Hob5V+J3X0eike/HFuTidVadicAII3bmHK2QeQciO8jdnuHR2AOetRtDPbPdYG9F9cCUt2MnwuO3oKHtPWa29BEnxj9jmdVKV+kwkEb+DwuBnKbV8fxGjVN9rMLceeg6e7jgfOeeMCHFdz/Ha76/ancP546KEnVbm7IQH1GxM4nNuuKudwNvOJoS505D4tbE9nSWdbztN/H9byl9B5KBlTXg+fuTypfcefhHfY8tCTqtRtMIHgDapyYbtQ3vPRFozWXtPTzuAdWYuZxQ7Rc6baVfc9bB+v9Tup7sZrsH9Jh0X9E4qUq3CZdqV2vQl17wp4/SZ68UL5VhPGrS0wF7+spf3+rlgM/VQOxy8V6pJh/c5dAh9LfNcBWjTipPZXrAB8PrFi+xq5cqoZXTVbvlCt1KYlMjC9BBXOlDO4uXwVXE2/c8ubad7U810JrFYuNu8EQ9WiMW6uQu+ZV2ecVEo6/WY7qUrNuiTUMHjtevEBdzeaUL/ZBHdXPcylr/OqNW8TabddycPIzct+VSO4pXA5fO6RGSeVwka/2U6qcmdtEu6sSzTATbiX+wrGzDWa7XLm8HnRmr5I77nhpE4O96LnxPN+J5WU02+2k6pUv8PA0+BjHTUszd1wtf4J1z3x3B3VcNb+rG84st6wXruKnmGhG8J4+y39ddxSwUJ9rwqn0CnVbydDwqXtDTufQNOe5Wjam4rmzFS07EtF6/5UNG1P1JeM4apJeGfuMrbdlsGSvxSWArZOi5aiu2Cx3vNsHa78/RYDG+D+tieyjpt42uWSET0XS+b/nlRSLf90VqpWL4IR/s8aXXltmn/V/JaMGrg5nVTDfxpoyViZcuX2m4tQtTrZD35nDSlPAlWNen6XLRmu3LDh+G6f40kl5fI/DdJ25faqRyDgUnmSplzYTqoTOZxXzah8TidVbDhj1WjD/QulY+96F742WQAAAABJRU5ErkJggg==\" y=\"105.2969\"/><text fill=\"#E2730E\" font-family=\"sans-serif\" font-size=\"16\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"27.7344\" x=\"129.4434\" y=\"150.1484\">api</text></g><!--link CorporateWebApp.api to CorporateWebApp.database--><g id=\"link_CorporateWebApp.api_CorporateWebApp.database\"><path d=\"M146.6705,164.3869 C149.6505,194.1869 153.184,229.5366 156.164,259.3166 \" fill=\"none\" id=\"CorporateWebApp.api-to-CorporateWebApp.database\" style=\"stroke:#707070;stroke-width:1;\"/><polygon fill=\"#707070\" points=\"156.9605,267.2769,159.1491,259.0179,153.1789,259.6153,156.9605,267.2769\" style=\"stroke:#707070;stroke-width:1;\"/><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"41.209\" x=\"154.3105\" y=\"206.4355\">Reads</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"195.5195\" y=\"206.4355\">&#160;</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"25.2305\" x=\"199.6973\" y=\"206.4355\">and</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"224.9277\" y=\"206.4355\">&#160;</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"42.1348\" x=\"229.1055\" y=\"206.4355\">writes</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"30.5215\" x=\"170.3008\" y=\"220.4043\">data</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"4.1777\" x=\"200.8223\" y=\"220.4043\">&#160;</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"50.25\" x=\"205\" y=\"220.4043\">from/to</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"12\" font-style=\"italic\" lengthAdjust=\"spacing\" textLength=\"56.3438\" x=\"184.6035\" y=\"234.373\">[http/api]</text></g><rect fill=\"none\" height=\"16.2969\" style=\"stroke:none;stroke-width:1;\" width=\"321.6211\" x=\"17\" y=\"376.2969\"/><text fill=\"#000000\" font-family=\"sans-serif\" font-size=\"14\" font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"57.9209\" x=\"17\" y=\"389.292\">Legend</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"79.7949\" y=\"389.292\">&#160;</text><rect fill=\"none\" height=\"16.2969\" style=\"stroke:none;stroke-width:1;\" width=\"321.6211\" x=\"17\" y=\"392.5938\"/><text fill=\"#444444\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"7.7041\" x=\"21.4502\" y=\"405.5889\"></text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"29.1543\" y=\"405.5889\">&#160;</text><text fill=\"#444444\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"121.7686\" x=\"38.0547\" y=\"405.5889\">system boundary</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"164.2734\" y=\"405.5889\">&#160;</text><rect fill=\"#DDDDDD\" height=\"30\" style=\"stroke:none;stroke-width:1;\" width=\"321.6211\" x=\"17\" y=\"408.8906\"/><text fill=\"#9A9A9A\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"7.7041\" x=\"21.4502\" y=\"435.5889\"></text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"29.1543\" y=\"435.5889\">&#160;</text><image height=\"30\" width=\"30\" x=\"33.6045\" xlink:href=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAYAAAA7MK6iAAAGZElEQVR4XpWXaUxUVxiGryjIvjOATdqIabQNdvnTNqnp8rdJ7Q9rWxXrUrcqKrggWFbBBcQFRWvSpGtsm9T+qG1NmybGLtFWSgVkV2BgYIABZmBwGAZmeHu+c+659w6QSic58edz3/d73+9DxXIwAj2HItkLhzU7HL054ej7IAz9uezlhWKgIBSDhfRCMFQUDEdxCBwlCzF8dCFGji/EaCm9IDwoC4LrZCBcpwLhPr0A7jML4KmYj4lz9AIweX4evBcD4Ls4D1MfzoNiORAJgndn0QdEwJpD8DANbssP4/CBghAMFjH4kWDYi9kHlARj5JiAO08ECfhJegRn4NOBGD8r4J6KAEycZ/DKAHgvCLjStT8KM+BcOcHDGTxUg0vl9iMhXPnw0WAMc3iQDi8L5PAxpnyMKZdwTbkKVzozo9C5L5LDuw8yy/3guu02sj1fVa7ChXIGPhasKpe2M9XlBCflZPt89gGqcgb3MrhiJnBmJKRyggvl4dz2vvx4DJQuYS8Fg2UpGDqZAvupFDhOs39LTRxOymezXcDlzAWcK2e2Kx17o2DOkHB6EX62j/56FpO2FkyYb4rXKd8t+Jw9sJdECOVkuxo4CXdpcBE2sp0rZ3ClfU80OjKiDfAo/gESTmD75fXoPWywnVseCk/LNTgvv6EFjs+cw9WZl6lhM9guZ6607Y4Bh+8leDSbN4Fl4CIZuIKDedqN8LwwOC69CO9QGwOHicCVSNvFzGXNdNtF2km9cj89Bm27ozV4B1cu4KTceaMCQ1+kqVWLmKY8DJPWGjgqn2UdF1XT0j7NdgkXVWPgeztjIOBG5WzuatrtVzJg/NG8Cd57mOChcHzyGrz9jeqCIbhMu141bclIeDmB34/Ff8G5ckPPvSNWDFSuMCgPZSGzYrA4VvTcANd7PlO50rojDhLelh47DS5nLnpO8P4zL8DT+RfveZ8KH/4qDRPd1eqSEcrlzB1kubZk9J4rLdvj0LojFq1S+S4GVuHte1TLSfmBGPQUpsCSFQXvg0H0lz3FF4xUjslx2AqjNbhYMnra/XrOAqc0b4uDhM+0PQa855nRGL5+Fr5JN1c++Fkaxmq/5apl2p1XM+Guu8LTLtcrV86PitxwOlxp2hoPHR7np1yzPSMGU54xePqaYbu0Et3ZCfCO2tB7dCl6VDjZPsVU9xdEi/Uqbefznlk1pfG9eBC8aWuc+gHS9lgNPvTDEThvfo6uvMfhtXfxtDu+y8Hob5V+J3X0eike/HFuTidVadicAII3bmHK2QeQciO8jdnuHR2AOetRtDPbPdYG9F9cCUt2MnwuO3oKHtPWa29BEnxj9jmdVKV+kwkEb+DwuBnKbV8fxGjVN9rMLceeg6e7jgfOeeMCHFdz/Ha76/ancP546KEnVbm7IQH1GxM4nNuuKudwNvOJoS505D4tbE9nSWdbztN/H9byl9B5KBlTXg+fuTypfcefhHfY8tCTqtRtMIHgDapyYbtQ3vPRFozWXtPTzuAdWYuZxQ7Rc6baVfc9bB+v9Tup7sZrsH9Jh0X9E4qUq3CZdqV2vQl17wp4/SZ68UL5VhPGrS0wF7+spf3+rlgM/VQOxy8V6pJh/c5dAh9LfNcBWjTipPZXrAB8PrFi+xq5cqoZXTVbvlCt1KYlMjC9BBXOlDO4uXwVXE2/c8ubad7U810JrFYuNu8EQ9WiMW6uQu+ZV2ecVEo6/WY7qUrNuiTUMHjtevEBdzeaUL/ZBHdXPcylr/OqNW8TabddycPIzct+VSO4pXA5fO6RGSeVwka/2U6qcmdtEu6sSzTATbiX+wrGzDWa7XLm8HnRmr5I77nhpE4O96LnxPN+J5WU02+2k6pUv8PA0+BjHTUszd1wtf4J1z3x3B3VcNb+rG84st6wXruKnmGhG8J4+y39ddxSwUJ9rwqn0CnVbydDwqXtDTufQNOe5Wjam4rmzFS07EtF6/5UNG1P1JeM4apJeGfuMrbdlsGSvxSWArZOi5aiu2Cx3vNsHa78/RYDG+D+tieyjpt42uWSET0XS+b/nlRSLf90VqpWL4IR/s8aXXltmn/V/JaMGrg5nVTDfxpoyViZcuX2m4tQtTrZD35nDSlPAlWNen6XLRmu3LDh+G6f40kl5fI/DdJ25faqRyDgUnmSplzYTqoTOZxXzah8TidVbDhj1WjD/QulY+96F742WQAAAABJRU5ErkJggg==\" y=\"408.8906\"/><text fill=\"#E2730E\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"226.1807\" x=\"72.5049\" y=\"435.5889\">Amazon Web Services - Lambda</text><text fill=\"#E2730E\" font-family=\"sans-serif\" font-size=\"10\" lengthAdjust=\"spacing\" textLength=\"31.0352\" x=\"303.1357\" y=\"436.5322\">(solid)</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"334.1709\" y=\"435.5889\">&#160;</text><rect fill=\"#DDDDDD\" height=\"30\" style=\"stroke:none;stroke-width:1;\" width=\"321.6211\" x=\"17\" y=\"438.8906\"/><text fill=\"#9A9A9A\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"7.7041\" x=\"21.4502\" y=\"465.5889\"></text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"29.1543\" y=\"465.5889\">&#160;</text><image height=\"30\" width=\"30\" x=\"33.6045\" xlink:href=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAYAAAA7MK6iAAAHDUlEQVR4Xn2Wi0+UVxrGv39nN9164SIgd4YZ5g4IbQUHuYiAl7rVXVmr7rpZdbNJ26ibmrY2u62xpqamXa3GXqStVFERFRjuwoDjCDgMDMN9YODZ857znW++AS3JSQgEfvM87/NelMwtXcgq7kHWGz3IfrMP2W89QU5JPwylHhhcg8jd/hTG8mcwVrBX6YOpehimnSPIq3kBc50flt0BWPaMw7p3Ata3J2H7Ywj2d6ZgPzANx59n4Tw4D2f9Apx/CSP/8BLyj0RQcHQZSmZhJwieWdTN4L0CvpXgAzBs8yC3bIjDc8u9Al71HKYdw8hjcHOtgJt3SXgQ1n0qfD8D/2mWwefgODgn4IcY/N0lFDC4kpHfgVg4U6+D5+jgBM5lz0TwaoKP6uBjHG4h5Srctn9Kg5NyR/088gnOlCvpznak57s1uLBdVU62lwrl3PYyoVwPJ9vNtQxcNxZrO8HfEcrtB2a47aRcwBcZ2N4GgmcUCOVZRV3YUv0ERTv7UVzrQfGuQQ4n5RIua87hZHuNVD7GlZceCsJ1JATX0RDK/kZgqvkMVy9rrqTZHiPN3irgTHlhZQ/oa2x8Ee6eOf5ytvarNR9k8CEYVOUUtmjNR7XANbvD6BxYQmBymf+vsr9OacrtZD2DK2nWR0iztQq4ox2FFT0MuoTJUAQ7Dg4K29+imvfrbI/W3PQK+O6TQYSmlzncdXSK2R6FU82VVPNDpFoI/hhke2FFF9q7ZrHjwACCkxFUM3j2mxIeTbtsNamcbM+rHuHwPcfHMTm1jL3/nERn/xK3XJ92giuppgcgeJoKd7o60PQgxG3fsb+fK7eX97281aRyzXYfivaNcqV7Toxz5Z39i9h2OBjbaky9kpJ7H6l5BG/RlEvb051u2Fw9urT3oLp+CJ9cDODqzRC+bQjh3KUJ1BwZial50b4RlnimXm01Le1vB2FjcPoAHJxibMZmDldtt0p4G097RkEn6o97EQ6voHdgHh9/4cffT42wN4qPL46j1xNGeHEF777vjx0yNdGayz4nuADn3IWAk/KWGOUlNd3wB8Jwbu9GYGIJD9qmYS3rQ25JHwwlT2As7YepzAPnziG0984jEIxg97FRTM0so+6YX6u5HDJSOQ0ZJTm7CRK+mZSzmmfaH+FWUxDPni+gfG8vb7UAS/rJMz4Meuf5hwhNRfij74d8YfzrIz8HU82rDg3DO7yI+21zsNbq+1zArQyuJGXegQY33OO2X70xhhs3A1rgyPIA62vjG6vHq0g79bm53CPAusBdaZhGw905nXKacGK2K0kZv0IPz7I0Y2o6wpVHbW/l4IXwMi5fC+DEaR/qT3jZe4YTZ4Zx+foE+90KB+v7nAJHtjt2qWHTbB+DsintFgT8NpKz7iDddA9z8xHk2B8weDOHk3KaZNatbvzjAy8+v/QC136cwPWbQZy/zD7Iv4fhrBrgYP1KNVc+xdzCCqzVvjUrVdmU+gsIvildwpvw/hkPenpnYHC0qIF7yMF1B/u0VqM+19u+54iX11v2uaVyEO4+1gFfTrx0pSqJKT8jCm/k8BRm+3unPZiZjeC/F3xIt7RwsH8szKbZEry+BXT2zvLnfc5+xoYMlYLAOQz82Vfj7G+XcfbCOIzbX75SlYTkBiSk/MTgDJzWGGN7qvEeLn09AoNTgMn2DJb47ILHsJV2wL6tA4biDuQUd3HlBK48MITvfgnB5NLP9rUrVUnYdBMJSQ1I3CyVNwrlGcL2ZLXVPjz3FItsSJw660XBNjfsJW4Optl++twwliIr+Oj8C5H2YvWMIttfsVKV+MQfES/hzPbEzcL2JLXmRsd9rdWM+S349LwP7q4Z9A3MssfWZvcM/nNxFJatnWKnM+UOOdvpkHjFSlXiE35Agg5ucdxBa3uIw11VD1lNWf86mzXlcsjwxbJqpdIZZXN1x6zUu49msKVWHBP6VlPi4r5DXPz3IOVku8V+G61tk3BVPMREcBFlVY94vanPOZwp18P1KzVDPSb0K9XdPYfiOs+alarEbbgBgser8DxrI/z+BQQZ1FXRsqbVNDhttVUrVX/JyJVKR0VRzcCalapsWHcdGzcKOCnPszTyc8U/tsCV324KiJrLtKsTTlr/spXazjJAxwR1An3R/cbvdj5en/BrhoGvYcP6KJxqnme+xZT/CrPtNsz2O1rgZJ9rtr9ipeZv70RBeRe/3wore/kBqZ/tpFzZ8IdvIeFxOuWy5onJP/G0yyEjlSexuv/WShU1d8dMOHk6092urH/tKiR8IylXa07wOEo8pT1Z3+cCnqyzfXXaCZ7KEk9bTX86C3g3shlcWff7/2H9a1cE/HVV+arAJSTpldOEk4Fbu1JF4MRikStVpl0/25V1v/sGq+GrlQs4G60xtsvxGguPKo+uVE25Dv5/ctkrSND6o90AAAAASUVORK5CYII=\" y=\"438.8906\"/><text fill=\"#3F51D4\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"199.2061\" x=\"72.5049\" y=\"465.5889\">Amazon Web Services - RDS</text><text fill=\"#3F51D4\" font-family=\"sans-serif\" font-size=\"10\" lengthAdjust=\"spacing\" textLength=\"31.0352\" x=\"276.1611\" y=\"466.5322\">(solid)</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"307.1963\" y=\"465.5889\">&#160;</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"8.4287\" x=\"21.4502\" y=\"481.8857\">&#9472;</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"29.8789\" y=\"481.8857\">&#160;</text><text fill=\"#707070\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"86.5703\" x=\"38.7793\" y=\"481.8857\">Relationship</text><text fill=\"#FFFFFF\" font-family=\"sans-serif\" font-size=\"14\" lengthAdjust=\"spacing\" textLength=\"4.4502\" x=\"129.7998\" y=\"481.8857\">&#160;</text><line style=\"stroke:none;stroke-width:1;\" x1=\"17\" x2=\"338.6211\" y1=\"376.2969\" y2=\"376.2969\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"17\" x2=\"338.6211\" y1=\"392.5938\" y2=\"392.5938\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"17\" x2=\"338.6211\" y1=\"408.8906\" y2=\"408.8906\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"17\" x2=\"338.6211\" y1=\"438.8906\" y2=\"438.8906\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"17\" x2=\"338.6211\" y1=\"468.8906\" y2=\"468.8906\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"17\" x2=\"338.6211\" y1=\"485.1875\" y2=\"485.1875\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"17\" x2=\"17\" y1=\"376.2969\" y2=\"485.1875\"/><line style=\"stroke:none;stroke-width:1;\" x1=\"338.6211\" x2=\"338.6211\" y1=\"376.2969\" y2=\"485.1875\"/><!--SRC=[jLDTQzim57tNhz2qFIImsFdgqfMvaALXUoWhn8Cy6jcwiSLioKWtozBI_px9paV9GXWhiy0sHz8zvvvxhmMa5cfkE6f3bLP0K689TAPDhHqAT0afdTOrxJbC8PSAZ2K4TKrHqrGZweeAQI13gHKXRwJAohK0-cas3cVZsrCWyL7W5vxVQCBV4Z8LObv21Gg_yxp3fXL_rAgH4eFvAJEmJiyzhrB1sNlwBirdkjGcOcz5ypIODWBC7l_8_VBuoj7iKHXEHdtmgAsDH8YOhFAR0h6sDs5eaQFC0ejcdU7Qo4SJPBeAiN32RCWRJRqDf3sxqzGRzeUZe3y8HeDmQh8YcIxZNgio6Ly7jSgVRCPBYFh1-CFrvEgvOIwuq1kfyeWTPSUuTSUOrQKKhFjtTYpkujTuCLfT3SJuFthHdd4gN-U5DsC1PME4-tBVThQGjR_W6skVpwJlbqTBrrJdqIOqZIZpSKcyjGXLybclbU1css678N1Ekn58qjsEkyx-6926d-SsOhjIiIvz8lGuDPsJS87Wo5DkmKNR_xP9P8Lg3H1WCzF-jg4lLjvbz2FogLmYvRLqVExzRrJ7cJkmFHFYwd2Uw4BA2-32Kgu4tVXsizJlqPNnNQLVYFCT6ExrDifEgtvGGkAl3ylaVlvb_kskupeLkhy1]--></g></svg>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "<buildzr.dsl.dsl.Workspace at 0xeaa34811c100>"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {
+      "application/json": {
+       "expanded": false,
+       "root": "workspace"
+      }
+     },
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Simply evaluate the workspace - Jupyter will call _repr_html_() automatically\n",
     "w"

--- a/tests/test_export_plantuml.py
+++ b/tests/test_export_plantuml.py
@@ -202,3 +202,102 @@ class TestPlantUmlSink:
             content = puml_files[0].read_text()
             assert '@startuml' in content
             assert '@enduml' in content
+
+    def test_filter_empty_sprite_tags(self) -> None:
+        """Test that AddElementTag lines with empty sprites are filtered out."""
+        sink = PlantUmlSink()
+
+        puml_content = """@startuml
+AddElementTag("WithIcon", $bgColor="#dddddd", $sprite="img:https://example.com/icon.png", $borderStyle="solid")
+AddElementTag("EmptySprite", $bgColor="#dddddd", $sprite="", $borderStyle="solid")
+AddElementTag("EmptySpriteAlt", $bgColor="#dddddd", $sprite='', $borderStyle="solid")
+AddBoundaryTag("Boundary", $bgColor="#ffffff", $borderColor="#9a9a9a")
+Person(User, "User")
+@enduml"""
+
+        filtered = sink._filter_empty_sprite_tags(puml_content)
+
+        # Lines with icons should be preserved
+        assert 'AddElementTag("WithIcon"' in filtered
+        # Lines with empty sprites should be removed
+        assert 'AddElementTag("EmptySprite"' not in filtered
+        assert 'AddElementTag("EmptySpriteAlt"' not in filtered
+        # AddBoundaryTag should be removed (no icons)
+        assert 'AddBoundaryTag' not in filtered
+        # Other content should be preserved
+        assert 'Person(User' in filtered
+        assert '@startuml' in filtered
+        assert '@enduml' in filtered
+
+    def test_clean_svg_legend(self) -> None:
+        """Test that placeholder characters are removed from SVG content."""
+        sink = PlantUmlSink()
+
+        # SVG content with placeholder character (&#9647; = U+25AF)
+        svg_content = b'<svg><text>&#9647;</text><text>Legend</text></svg>'
+
+        cleaned = sink._clean_svg_legend(svg_content)
+
+        # Placeholder should be removed
+        assert b'&#9647;' not in cleaned
+        # Other content preserved
+        assert b'Legend' in cleaned
+        assert b'<svg>' in cleaned
+
+    def test_clean_svg_legend_unicode_literal(self) -> None:
+        """Test that Unicode literal placeholder is also removed."""
+        sink = PlantUmlSink()
+
+        # SVG content with Unicode literal (▯)
+        svg_content = '▯ Legend'.encode('utf-8')
+
+        cleaned = sink._clean_svg_legend(svg_content)
+
+        # Unicode literal should be removed
+        assert '\u25af'.encode('utf-8') not in cleaned
+        assert b'Legend' in cleaned
+
+    def test_svg_export_no_placeholder_characters(self) -> None:
+        """Test that SVG export removes placeholder characters via save()."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create workspace with styled elements
+            with Workspace('Test', 'Test workspace') as w:
+                user = Person('User')
+                with SoftwareSystem('System') as system:
+                    container = Container('Container')
+                user >> "Uses" >> container
+
+                SystemContextView(system, key='context', description='Test context')
+
+            # Export to SVG
+            w.save(format='svg', path=temp_dir)
+
+            # Check SVG files for placeholder characters
+            svg_files = list(Path(temp_dir).glob("*.svg"))
+            assert len(svg_files) > 0
+
+            for svg_file in svg_files:
+                content = svg_file.read_text()
+                # No placeholder characters should be present
+                assert '&#9647;' not in content, f"Found placeholder in {svg_file.name}"
+                assert '\u25af' not in content, f"Found Unicode placeholder in {svg_file.name}"
+
+    def test_to_svg_no_placeholder_characters(self) -> None:
+        """Test that to_svg() removes placeholder characters (used by Jupyter)."""
+        # Create workspace with styled elements
+        with Workspace('Test', 'Test workspace') as w:
+            user = Person('User')
+            with SoftwareSystem('System') as system:
+                container = Container('Container')
+            user >> "Uses" >> container
+
+            SystemContextView(system, key='context', description='Test context')
+
+        # Get SVG via to_svg() method (used by Jupyter notebooks)
+        svgs = w.to_svg()
+
+        assert len(svgs) > 0
+        for view_key, svg_content in svgs.items():
+            # No placeholder characters should be present
+            assert '&#9647;' not in svg_content, f"Found placeholder in {view_key}"
+            assert '\u25af' not in svg_content, f"Found Unicode placeholder in {view_key}"


### PR DESCRIPTION
## Summary
- Applies `_clean_svg_legend()` cleanup to `render_to_svg_dict()` method
- Ensures placeholder characters are removed when using `to_svg()` in Jupyter notebooks
- Adds test cases for the SVG cleanup functionality

## Context
PR #108 fixed the placeholder character issue for file exports (`w.save(format='svg')`), but the fix wasn't applied to the in-memory `to_svg()` method used by Jupyter notebooks.

## Test plan
- [x] All existing tests pass
- [x] New tests verify placeholder cleanup works for both HTML entities and Unicode literals
- [x] Integration tests verify both `save(format='svg')` and `to_svg()` remove placeholders

🤖 Generated with [Claude Code](https://claude.com/claude-code)